### PR TITLE
feat: add a login alarm for ops1 and ops2

### DIFF
--- a/terragrunt/main/alarms.tf
+++ b/terragrunt/main/alarms.tf
@@ -1,0 +1,16 @@
+resource "aws_sns_topic" "critical" { 
+  name = "critical-issue"
+}
+
+resource "aws_sns_topic" "warning" {
+  name = "warning-issue"
+}
+
+module "alarm_actions" {
+
+  account_names = ["Ops1", "Ops2"]
+  log_group_name = "aws-controltower/CloudTrailLogs"
+  alarm_actions_success = [aws_sns_topic.crtical.arn]
+  alarm_actions_failure = [aws_sns_topic.warning.arn]
+  num_attempts = 2
+}


### PR DESCRIPTION
# Summary | Résumé

- Creates two sns topics one warn and one critical
- Alerts when users try to login, alerts on the warning topic when 2
  failures occur, alert on critical when a success occurs


