### PR TITLE
feat: add a new admin plan role

### DIFF
--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -1,13 +1,13 @@
 name: "Terraform Apply"
-
 on:
   push:
     branches:
       - main
-
 env:
-  TERRAFORM_VERSION: 1.1.6
-  TERRAGRUNT_VERSION: v0.36.2
+  AWS_REGION: "ca-central-1"
+  TERRAFORM_VERSION: 1.1.7
+  TERRAGRUNT_VERSION: 0.36.3
+  CONFTEST_VERSION: 0.30.0
 
 permissions:
   id-token: write
@@ -21,31 +21,19 @@ jobs:
   terragrunt-apply-org-account:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
-    env:
-      AWS_REGION: ca-central-1
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1.2.1
-        with:
-          terraform_version: ${{ env.TERRAFORM_VERSION }}
-          terraform_wrapper: false
-
-      - name: Setup Terragrunt
-        run: |
-          mkdir -p bin
-          wget -O bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/$TERRAGRUNT_VERSION/terragrunt_linux_amd64
-          chmod +x bin/terragrunt
-          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+      - name: setup terraform tools
+        uses: cds-snc/terraform-tools-setup@v1
 
       - name: Configure aws credentials using OIDC
         uses: aws-actions/configure-aws-credentials@master
         with:
           role-to-assume: arn:aws:iam::659087519042:role/CDSLZTerraformAdministratorRole
           role-session-name: SREBotGitHubActions
-          aws-region: "ca-central-1"
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Terraform apply main
         working-directory: terragrunt/org_account/main
@@ -55,31 +43,16 @@ jobs:
   terragrunt-apply-aft-account:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
-    env:
-      AWS_REGION: ca-central-1
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1.2.1
-        with:
-          terraform_version: ${{ env.TERRAFORM_VERSION }}
-          terraform_wrapper: false
-
-      - name: Setup Terragrunt
-        run: |
-          mkdir -p bin
-          wget -O bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/$TERRAGRUNT_VERSION/terragrunt_linux_amd64
-          chmod +x bin/terragrunt
-          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
 
       - name: Configure aws credentials using OIDC
         uses: aws-actions/configure-aws-credentials@master
         with:
           role-to-assume: arn:aws:iam::137554749751:role/CDSLZTerraformAdministratorRole
           role-session-name: SREBotGitHubActions
-          aws-region: "ca-central-1"
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Terraform apply aft
         working-directory: terragrunt/org_account/main

--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -81,5 +81,3 @@ jobs:
           directory: ./terragrunt/aft/${{ matrix.module }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           terragrunt: true
-
-  terraform-plan

--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -6,10 +6,10 @@ on:
       - "terragrunt/**"
       - ".github/workflows/**"
 env:
-  AWS_REGION: ca-central-1
-  TERRAFORM_VERSION: 1.1.6
-  TERRAGRUNT_VERSION: v0.36.2
-  CONFTEST_VERSION: 0.27.0
+  AWS_REGION: "ca-central-1"
+  TERRAFORM_VERSION: 1.1.7
+  TERRAGRUNT_VERSION: 0.36.3
+  CONFTEST_VERSION: 0.30.0
 
 permissions:
   id-token: write
@@ -32,34 +32,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1.2.1
-        with:
-          terraform_version: ${{ env.TERRAFORM_VERSION }}
-          terraform_wrapper: false
-
-      - name: Setup Terragrunt
-        run: |
-          mkdir -p bin
-          wget -O bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/$TERRAGRUNT_VERSION/terragrunt_linux_amd64
-          chmod +x bin/*
-          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
-
-      - name: Install Conftest
-        run: |
-          wget "https://github.com/open-policy-agent/conftest/releases/download/v${{ env.CONFTEST_VERSION }}/conftest_${{ env.CONFTEST_VERSION }}_Linux_x86_64.tar.gz" \
-          && wget "https://github.com/open-policy-agent/conftest/releases/download/v${{ env.CONFTEST_VERSION }}/checksums.txt" \
-          && grep 'Linux_x86_64.tar.gz' < checksums.txt | sha256sum --check  --status \
-          && tar -zxvf "conftest_${{ env.CONFTEST_VERSION }}_Linux_x86_64.tar.gz" conftest \
-          && mv conftest /usr/local/bin \
-          && rm "conftest_${{ env.CONFTEST_VERSION }}_Linux_x86_64.tar.gz" checksums.txt
+      - name: setup terraform tools
+        uses: cds-snc/terraform-tools-setup@v1
 
       - name: Configure aws credentials using OIDC
         uses: aws-actions/configure-aws-credentials@master
         with:
           role-to-assume: arn:aws:iam::659087519042:role/CDSLZTerraformReadOnlyRole
           role-session-name: CDSAWSLZGitHubActions
-          aws-region: "ca-central-1"
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Terraform Plan for org_account/${{ matrix.module }}
         uses: cds-snc/terraform-plan@v2
@@ -82,34 +63,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1.2.1
-        with:
-          terraform_version: ${{ env.TERRAFORM_VERSION }}
-          terraform_wrapper: false
-
-      - name: Setup Terragrunt
-        run: |
-          mkdir -p bin
-          wget -O bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/$TERRAGRUNT_VERSION/terragrunt_linux_amd64
-          chmod +x bin/*
-          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
-
-      - name: Install Conftest
-        run: |
-          wget "https://github.com/open-policy-agent/conftest/releases/download/v${{ env.CONFTEST_VERSION }}/conftest_${{ env.CONFTEST_VERSION }}_Linux_x86_64.tar.gz" \
-          && wget "https://github.com/open-policy-agent/conftest/releases/download/v${{ env.CONFTEST_VERSION }}/checksums.txt" \
-          && grep 'Linux_x86_64.tar.gz' < checksums.txt | sha256sum --check  --status \
-          && tar -zxvf "conftest_${{ env.CONFTEST_VERSION }}_Linux_x86_64.tar.gz" conftest \
-          && mv conftest /usr/local/bin \
-          && rm "conftest_${{ env.CONFTEST_VERSION }}_Linux_x86_64.tar.gz" checksums.txt
+      - name: setup terraform tools
+        uses: cds-snc/terraform-tools-setup@v1
 
       - name: Configure aws credentials using OIDC
         uses: aws-actions/configure-aws-credentials@master
         with:
           role-to-assume: arn:aws:iam::137554749751:role/CDSLZTerraformReadOnlyRole
           role-session-name: CDSAWSLZGitHubActions
-          aws-region: "ca-central-1"
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Terraform Plan for aft/${{ matrix.module }}
         uses: cds-snc/terraform-plan@v2
@@ -119,3 +81,5 @@ jobs:
           directory: ./terragrunt/aft/${{ matrix.module }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           terragrunt: true
+
+  terraform-plan

--- a/terragrunt/org_account/main/oidc_role.tf
+++ b/terragrunt/org_account/main/oidc_role.tf
@@ -1,6 +1,7 @@
 locals {
   plan_name  = "CDSLZTerraformReadOnlyRole"
   admin_name = "CDSLZTerraformAdministratorRole"
+  admin_plan_role = "CDSLZTerraformAdminPlanRole"
 }
 
 data "aws_caller_identity" "current" {}
@@ -17,6 +18,11 @@ module "gh_oidc_roles" {
       name      = local.admin_name
       repo_name = "cds-aws-lz"
       claim     = "ref:refs/heads/main"
+    },
+    {
+      name      = local.admin_plan_role
+      repo_name = "cds-aws-lz"
+      claim     = "*"
     }
   ]
 
@@ -45,6 +51,14 @@ data "aws_iam_policy" "admin" {
 
 resource "aws_iam_role_policy_attachment" "admin" {
   role       = local.admin_name
+  policy_arn = data.aws_iam_policy.admin.arn
+  depends_on = [
+    module.gh_oidc_roles
+  ]
+}
+
+resource "aws_iam_role_policy_attachment" "admin" {
+  role       = local.admin_plan_role
   policy_arn = data.aws_iam_policy.admin.arn
   depends_on = [
     module.gh_oidc_roles

--- a/terragrunt/org_account/main/oidc_role.tf
+++ b/terragrunt/org_account/main/oidc_role.tf
@@ -57,7 +57,7 @@ resource "aws_iam_role_policy_attachment" "admin" {
   ]
 }
 
-resource "aws_iam_role_policy_attachment" "admin" {
+resource "aws_iam_role_policy_attachment" "admin_plan" {
   role       = local.admin_plan_role
   policy_arn = data.aws_iam_policy.admin.arn
   depends_on = [

--- a/terragrunt/org_account/main/oidc_role.tf
+++ b/terragrunt/org_account/main/oidc_role.tf
@@ -1,6 +1,6 @@
 locals {
-  plan_name  = "CDSLZTerraformReadOnlyRole"
-  admin_name = "CDSLZTerraformAdministratorRole"
+  plan_name       = "CDSLZTerraformReadOnlyRole"
+  admin_name      = "CDSLZTerraformAdministratorRole"
   admin_plan_role = "CDSLZTerraformAdminPlanRole"
 }
 


### PR DESCRIPTION
# Summary | Résumé

Adding a role that we can use to run plan on the AFT Module.

Also migrate to the new Terraform Tools setup action


