### PR TITLE
feat: attach the AFTExecution role to AF

### DIFF
--- a/terragrunt/org_account/main/main.tf
+++ b/terragrunt/org_account/main/main.tf
@@ -1,3 +1,20 @@
 module "password_policy" {
   source = "../modules/password_policy"
 }
+
+
+
+# Grant access to the AFT Management account to AFT Product in the Service Catalog:
+# https://learn.hashicorp.com/tutorials/terraform/aws-control-tower-aft#grant-aft-access-to-service-catalog-portfolio
+data "aws_servicecatalog_portfolio" "account_factory" {
+  id = "port-dpatq4en6lqoy"
+}
+
+data "aws_iam_role" "aft_execution_role" {
+  name = "AWSAFTExecution"
+}
+
+resource "aws_servicecatalog_principal_portfolio_association" "aft_role_account_factory" {
+  portfolio_id  = data.aws_servicecatalog_portfolio.account_factory.id
+  principal_arn = data.aws_iam_role.aft_execution_role.arn
+}


### PR DESCRIPTION
# Summary | Résumé

This is a required action so that Account Factory for Terraform has the
ability to trigger Account Factory in the root account.

https://learn.hashicorp.com/tutorials/terraform/aws-control-tower-aft#grant-aft-access-to-service-catalog-portfolio

Related to https://github.com/cds-snc/site-reliability-engineering/issues/393