### PR TITLE
feat: notify in slack on AFT notifications

### DIFF
--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -50,6 +50,9 @@ jobs:
   terragrunt-apply-aft-account:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
+    env:
+      TF_VAR_aft_slack_webhook: ${{ secrets.LZ_CHANNEL_WEBHOOK }}
+
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -59,6 +59,8 @@ jobs:
           - module: main
 
     runs-on: ubuntu-latest
+    env:
+      TF_VAR_aft_slack_webhook: ${{ secrets.LZ_CHANNEL_WEBHOOK }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/terragrunt/aft/main/slack_notify.tf
+++ b/terragrunt/aft/main/slack_notify.tf
@@ -1,0 +1,24 @@
+module "aft_slack_notification" {
+  source            = "github.com/cds-snc/terraform-modules?ref=v2.0.0//notify_slack"
+  billing_tag_value = var.billing_code
+  function_name     = "aft_slack_notification"
+  project_name      = "Account Factory for Terraform"
+  slack_webhook_url = var.aft_slack_webhook
+
+  sns_topic_arns = [
+    data.aws_sns_topic.aft_failure_notifications.arn,
+    data.aws_sns_topic.aft_notifications.arn
+  ]
+}
+
+data "aws_sns_topic" "aft_failure_notifications" {
+  name = "aft-failure-notifications"
+}
+
+data "aws_sns_topic" "aft_notifications" {
+  name = "aft-notifications"
+}
+
+variable "aft_slack_webhook" {
+  description = "The slack webhook URL to be used by Account Factory for Terraform"
+}


### PR DESCRIPTION
# Summary | Résumé

This should notify in the landing zone slack channel on messages sent to
aft-failure-notifications and aft-notifications.


This will close #16 