### PR TITLE
feat: add OIDC to Log Archive Account

### DIFF
--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -70,7 +70,7 @@ jobs:
           role-session-name: SREBotGitHubActions
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Terraform apply audit ${{ matrix.module }}
+      - name: Terraform apply log-archive ${{ matrix.module }}
         working-directory: terragrunt/audit/${{ matrix.module }}
         run: |
           terragrunt apply --terragrunt-non-interactive -auto-approve

--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -12,21 +12,35 @@ env:
 permissions:
   id-token: write
   contents: read
-  pull-requests: write
-  actions: write
-  checks: write
-  statuses: write
 
 jobs:
-  terragrunt-apply-org-account:
+  terragrunt-apply-account:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
         include:
-        - module: main
-        - module: aft
+
+        - account_folder: org_account
+          module: main
+          account: 659087519042
+
+        - account_folder: org_account
+          module: aft
+          account: 659087519042
+
+        - account_folder: log_archive
+          module: main
+          account: 274536870005
+
+        - account_folder: audit
+          module: main
+          account: 886481071419
+
+        - account_folder: aft
+          module: main
+          account: 137554749751
 
     steps:
       - name: Checkout
@@ -38,98 +52,11 @@ jobs:
       - name: Configure aws credentials using OIDC
         uses: aws-actions/configure-aws-credentials@master
         with:
-          role-to-assume: arn:aws:iam::659087519042:role/CDSLZTerraformAdministratorRole
-          role-session-name: SREBotGitHubActions
+          role-to-assume: arn:aws:iam::${{ matrix.account }}:role/CDSLZTerraformAdministratorRole
+          role-session-name: ${{matrix.account}}|${{matrix.module}}|apply
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Terraform apply aft ${{ matrix.module }}
-        working-directory: terragrunt/org_account/${{ matrix.module }}
-        run: |
-          terragrunt apply --terragrunt-non-interactive -auto-approve
-
-  terragrunt-apply-log-archive-account:
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-        - module: main
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: setup terraform tools
-        uses: cds-snc/terraform-tools-setup@v1
-
-      - name: Configure aws credentials using OIDC
-        uses: aws-actions/configure-aws-credentials@master
-        with:
-          role-to-assume: arn:aws:iam::274536870005:role/CDSLZTerraformAdministratorRole
-          role-session-name: SREBotGitHubActions
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Terraform apply log-archive ${{ matrix.module }}
-        working-directory: terragrunt/log_archive/${{ matrix.module }}
-        run: |
-          terragrunt apply --terragrunt-non-interactive -auto-approve
-
-  terragrunt-apply-audit-account:
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-        - module: main
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: setup terraform tools
-        uses: cds-snc/terraform-tools-setup@v1
-
-      - name: Configure aws credentials using OIDC
-        uses: aws-actions/configure-aws-credentials@master
-        with:
-          role-to-assume: arn:aws:iam::886481071419:role/CDSLZTerraformAdministratorRole
-          role-session-name: SREBotGitHubActions
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Terraform apply audit ${{ matrix.module }}
-        working-directory: terragrunt/audit/${{ matrix.module }}
-        run: |
-          terragrunt apply --terragrunt-non-interactive -auto-approve
-
-  terragrunt-apply-aft-account:
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    runs-on: ubuntu-latest
-    env:
-      TF_VAR_aft_slack_webhook: ${{ secrets.LZ_CHANNEL_WEBHOOK }}
-
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-        - module: main
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: setup terraform tools
-        uses: cds-snc/terraform-tools-setup@v1
-
-      - name: Configure aws credentials using OIDC
-        uses: aws-actions/configure-aws-credentials@master
-        with:
-          role-to-assume: arn:aws:iam::137554749751:role/CDSLZTerraformAdministratorRole
-          role-session-name: SREBotGitHubActions
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Terraform apply aft ${{ matrix.module }}
-        working-directory: terragrunt/aft/${{ matrix.module }}
+      - name: Terraform apply ${{matrix.account_folder}}/${{ matrix.module }}
+        working-directory: terragrunt/${{ matrix.account_folder }}/${{ matrix.module }}
         run: |
           terragrunt apply --terragrunt-non-interactive -auto-approve

--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -53,7 +53,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@master
         with:
           role-to-assume: arn:aws:iam::${{ matrix.account }}:role/CDSLZTerraformAdministratorRole
-          role-session-name: ${{matrix.account}}|${{matrix.module}}|apply
+          role-session-name: ${{matrix.account}}-${{matrix.module}}-apply
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Terraform apply ${{matrix.account_folder}}/${{ matrix.module }}

--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -47,6 +47,34 @@ jobs:
         run: |
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
+  terragrunt-apply-log-archive-account:
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+        - module: main
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: setup terraform tools
+        uses: cds-snc/terraform-tools-setup@v1
+
+      - name: Configure aws credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@master
+        with:
+          role-to-assume: arn:aws:iam::274536870005:role/CDSLZTerraformAdministratorRole
+          role-session-name: SREBotGitHubActions
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Terraform apply audit ${{ matrix.module }}
+        working-directory: terragrunt/audit/${{ matrix.module }}
+        run: |
+          terragrunt apply --terragrunt-non-interactive -auto-approve
+
   terragrunt-apply-audit-account:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest

--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -71,7 +71,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Terraform apply log-archive ${{ matrix.module }}
-        working-directory: terragrunt/audit/${{ matrix.module }}
+        working-directory: terragrunt/log_archive/${{ matrix.module }}
         run: |
           terragrunt apply --terragrunt-non-interactive -auto-approve
 

--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -77,8 +77,8 @@ jobs:
         uses: cds-snc/terraform-plan@v2
         with:
           comment-delete: true
-          comment-title: Plan for Audit ${{ matrix.module }}
-          directory: ./terragrunt/audit/${{ matrix.module }}
+          comment-title: Plan for log_archive/${{ matrix.module }}
+          directory: ./terragrunt/log_archive/${{ matrix.module }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           terragrunt: true
 

--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -69,7 +69,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@master
         with:
           role-to-assume: arn:aws:iam::${{ matrix.account }}:role/${{ matrix.role }}
-          role-session-name: ${{matrix.account}}|${{matrix.module}}|${{matrix.role}}|plan
+          role-session-name: ${{matrix.account}}-${{matrix.module}}-${{matrix.role}}-plan
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Terraform Plan for ${{matrix.module }}/${{ matrix.module }}

--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -41,11 +41,6 @@ jobs:
             account: 886481071419
             role: CDSLZTerraformReadOnlyRole
 
-          - account_folder: org_account
-            module: main
-            account: 137554749751
-            role: CDSLZTerraformReadOnlyRole
-
           - account_folder: aft
             module: main
             account: 137554749751
@@ -83,4 +78,3 @@ jobs:
           directory: ./terragrunt/${{ matrix.account_folder }}/${{ matrix.module }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           terragrunt: true
-          plan-character-limit: 60000

--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -20,12 +20,42 @@ permissions:
   statuses: write
 
 jobs:
-  terraform-plan-org-account:
+
+  terraform-plan-account:
     strategy:
       fail-fast: false
       matrix:
         include:
-          - module: main
+          - account_folder: org_account
+            module: main
+            account: 659087519042
+            role: CDSLZTerraformReadOnlyRole
+
+          - account_folder: log_archive
+            module: main
+            account: 274536870005
+            role: CDSLZTerraformReadOnlyRole
+
+          - account_folder: audit
+            module: main
+            account: 886481071419
+            role: CDSLZTerraformReadOnlyRole
+
+          - account_folder: org_account
+            module: main
+            account: 137554749751
+            role: CDSLZTerraformReadOnlyRole
+
+          - account_folder: aft
+            module: main
+            account: 137554749751
+            role: CDSLZTerraformReadOnlyRole
+            lz_webhook_key: LZ_CHANNEL_WEBHOOK
+
+          - account_folder: org_account
+            module: aft
+            account: 659087519042
+            role: CDSLZTerraformAdminPlanRole
 
     runs-on: ubuntu-latest
     steps:
@@ -38,137 +68,19 @@ jobs:
       - name: Configure aws credentials using OIDC
         uses: aws-actions/configure-aws-credentials@master
         with:
-          role-to-assume: arn:aws:iam::659087519042:role/CDSLZTerraformReadOnlyRole
-          role-session-name: CDSAWSLZGitHubActions
+          role-to-assume: arn:aws:iam::${{ matrix.account }}:role/${{ matrix.role }}
+          role-session-name: ${{matrix.account}}|${{matrix.module}}|${{matrix.role}}|plan
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Terraform Plan for org_account/${{ matrix.module }}
+      - name: Terraform Plan for ${{matrix.module }}/${{ matrix.module }}
+        # I have no idea if this will work.
+        env:
+          TF_VAR_aft_slack_webhook: ${{ secrets[matrix.lz_webhook_key] }}
         uses: cds-snc/terraform-plan@v2
         with:
           comment-delete: true
-          comment-title: Plan for ${{ matrix.module }}
-          directory: ./terragrunt/org_account/${{ matrix.module }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          terragrunt: true
-
-  terraform-plan-log-archive-account:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - module: main
-
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: setup terraform tools
-        uses: cds-snc/terraform-tools-setup@v1
-
-      - name: Configure aws credentials using OIDC
-        uses: aws-actions/configure-aws-credentials@master
-        with:
-          role-to-assume: arn:aws:iam::274536870005:role/CDSLZTerraformReadOnlyRole
-          role-session-name: CDSAWSLZGitHubActions
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Terraform Plan for audit/${{ matrix.module }}
-        uses: cds-snc/terraform-plan@v2
-        with:
-          comment-delete: true
-          comment-title: Plan for log_archive/${{ matrix.module }}
-          directory: ./terragrunt/log_archive/${{ matrix.module }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          terragrunt: true
-
-  terraform-plan-audit-account:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - module: main
-
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: setup terraform tools
-        uses: cds-snc/terraform-tools-setup@v1
-
-      - name: Configure aws credentials using OIDC
-        uses: aws-actions/configure-aws-credentials@master
-        with:
-          role-to-assume: arn:aws:iam::886481071419:role/CDSLZTerraformReadOnlyRole
-          role-session-name: CDSAWSLZGitHubActions
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Terraform Plan for audit/${{ matrix.module }}
-        uses: cds-snc/terraform-plan@v2
-        with:
-          comment-delete: true
-          comment-title: Plan for Audit ${{ matrix.module }}
-          directory: ./terragrunt/audit/${{ matrix.module }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          terragrunt: true
-
-  terraform-plan-aft-account:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - module: main
-
-    runs-on: ubuntu-latest
-    env:
-      TF_VAR_aft_slack_webhook: ${{ secrets.LZ_CHANNEL_WEBHOOK }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: setup terraform tools
-        uses: cds-snc/terraform-tools-setup@v1
-
-      - name: Configure aws credentials using OIDC
-        uses: aws-actions/configure-aws-credentials@master
-        with:
-          role-to-assume: arn:aws:iam::137554749751:role/CDSLZTerraformReadOnlyRole
-          role-session-name: CDSAWSLZGitHubActions
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Terraform Plan for aft/${{ matrix.module }}
-        uses: cds-snc/terraform-plan@v2
-        with:
-          comment-delete: true
-          comment-title: Plan for ${{ matrix.module }}
-          directory: ./terragrunt/aft/${{ matrix.module }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          terragrunt: true
-
-  terraform-plan-admin-aft-module:
-
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: setup terraform tools
-        uses: cds-snc/terraform-tools-setup@v1
-
-      - name: Configure aws credentials using OIDC
-        uses: aws-actions/configure-aws-credentials@master
-        with:
-          role-to-assume: arn:aws:iam::659087519042:role/CDSLZTerraformAdminPlanRole
-          role-session-name: CDSAWSLZAdminPlanGitHubActions
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Terraform Plan for aft admin/${{ matrix.module }}
-        uses: cds-snc/terraform-plan@v2
-        with:
-          comment-delete: true
-          comment-title: Plan for AFT Root Module
-          directory: ./terragrunt/org_account/aft
+          comment-title: Plan for ${{matrix.account_folder}}/${{ matrix.module }}
+          directory: ./terragrunt/${{ matrix.account_folder }}/${{ matrix.module }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           terragrunt: true
           plan-character-limit: 60000

--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -51,6 +51,37 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           terragrunt: true
 
+  terraform-plan-log-archive-account:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - module: main
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: setup terraform tools
+        uses: cds-snc/terraform-tools-setup@v1
+
+      - name: Configure aws credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@master
+        with:
+          role-to-assume: arn:aws:iam::274536870005:role/CDSLZTerraformReadOnlyRole
+          role-session-name: CDSAWSLZGitHubActions
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Terraform Plan for audit/${{ matrix.module }}
+        uses: cds-snc/terraform-plan@v2
+        with:
+          comment-delete: true
+          comment-title: Plan for Audit ${{ matrix.module }}
+          directory: ./terragrunt/audit/${{ matrix.module }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          terragrunt: true
+
   terraform-plan-audit-account:
     strategy:
       fail-fast: false

--- a/terragrunt/audit/main/main.tf
+++ b/terragrunt/audit/main/main.tf
@@ -1,6 +1,6 @@
 locals {
-  plan_name     = "CDSLZTerraformReadOnlyRole"
-  admin_name    = "CDSLZTerraformAdministratorRole"
+  plan_name  = "CDSLZTerraformReadOnlyRole"
+  admin_name = "CDSLZTerraformAdministratorRole"
 }
 
 data "aws_caller_identity" "current" {}

--- a/terragrunt/audit/main/main.tf
+++ b/terragrunt/audit/main/main.tf
@@ -1,8 +1,6 @@
 locals {
   plan_name     = "CDSLZTerraformReadOnlyRole"
   admin_name    = "CDSLZTerraformAdministratorRole"
-  sc_plan_name  = "SCCDSLZTerraformReadOnlyRole"
-  sc_admin_name = "SCCDSLZTerraformAdministratorRole"
 }
 
 data "aws_caller_identity" "current" {}

--- a/terragrunt/log_archive/main/.terraform.lock.hcl
+++ b/terragrunt/log_archive/main/.terraform.lock.hcl
@@ -1,0 +1,40 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.75.1"
+  constraints = "< 4.0.0"
+  hashes = [
+    "h1:++H0a4igODgreQL3SJuRz71JZkC69rl41R8xLYM894o=",
+    "zh:11c2ee541ca1da923356c9225575ba294523d7b6af82d6171c912470ef0f90cd",
+    "zh:19fe975993664252b4a2ff1079546f2b186b01d1a025a94a4f15c37e023806c5",
+    "zh:442e7fc145b2debebe9279b283d07f5f736dc1776c2e5b1702728a6eb03789d0",
+    "zh:7a77991b204ae2c16ac29a32226135d5fdbda40c8dafa77c5adf5439a346be77",
+    "zh:89a257933181c15293c15a858fbfe7252129cc57cc2ec05b6c0b595d1bfe9d38",
+    "zh:b1813ea5b6b0fd88ea85b1b21b8e4119566d1bc34feca297b4fb39d0536893cb",
+    "zh:c519f3292ae431bd2381f88a95bd37c52f7a56d91feef88511e929344c180549",
+    "zh:d3dbe88b661c073c174f04f73adc2720372143bdfa12f4fe8f411332e64662cf",
+    "zh:e92a27e3c7295b031b5d62dd9428966c96e3157fc768b3d848a9ac60d1661c8e",
+    "zh:ecd664c0d664fcf2d8a89a01462cb00bcae37da200305aef2de1b8fe185c9cd8",
+    "zh:ed6ce1f9fa96aa28dd65842f852abed25f919d20b5cf53d26cec5b3f4d845725",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version = "3.3.0"
+  hashes = [
+    "h1:xx/b39Q9FVZSlDc97rlDmQ9dNaaxFFyVzP9kV+47z28=",
+    "zh:16140e8cc880f95b642b6bf6564f4e98760e9991864aacc8e21273423571e561",
+    "zh:16338b8457759c97fdd73153965d6063b037f2954fd512e569fcdc42b7fef743",
+    "zh:348bd44b7cd0c6d663bba36cecb474c17635a8f22b02187d034b8e57a8729c5a",
+    "zh:3832ac73c2335c0fac26138bacbd18160efaa3f06c562869acc129e814e27f86",
+    "zh:756d1e60690d0164eee9c93b498b4c8beabbfc1d8b7346cb6d2fa719055089d6",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:93b911bcddba8dadc5339edb004c8019c230ea67477c73c4f741c236dd9511b1",
+    "zh:c0c4e5742e8ac004c507540423db52af3f44b8ec04443aa8e14669340819344f",
+    "zh:c78296a1dff8ccd5d50203aac353422fc18d425072ba947c88cf5b46de7d32d2",
+    "zh:d7143f444e0f7e6cd67fcaf080398b4f1487cf05de3e0e79af6c14e22812e38b",
+    "zh:e600ac76b118816ad72132eee4c22ab5fc044f67c3babc54537e1fc1ad53d295",
+    "zh:fca07af5f591e12d2dc178a550da69a4847bdb34f8180a5b8e04fde6b528cf99",
+  ]
+}

--- a/terragrunt/log_archive/main/main.tf
+++ b/terragrunt/log_archive/main/main.tf
@@ -19,6 +19,16 @@ module "gh_oidc_roles" {
       name      = local.admin_name
       repo_name = "cds-aws-lz"
       claim     = "ref:refs/heads/main"
+    },
+    {
+      name      = local.sc_plan_name
+      repo_name = "sentinel-connectors"
+      claim     = "*"
+    },
+    {
+      name      = local.sc_admin_name
+      repo_name = "sentinel-connectors"
+      claim     = "ref:refs/heads/main"
     }
   ]
   oidc_exists       = false
@@ -38,6 +48,19 @@ module "attach_tf_plan_policy" {
   ]
 }
 
+module "attach_tf_plan_policy_sc" {
+  source            = "github.com/cds-snc/terraform-modules?ref=v2.0.2//attach_tf_plan_policy"
+  account_id        = data.aws_caller_identity.current.account_id
+  role_name         = local.sc_plan_name
+  bucket_name       = "${var.billing_code}-tf"
+  lock_table_name   = "terraform-state-lock-dynamo"
+  billing_tag_value = var.billing_code
+  policy_name       = "SCCDSLZTFPlan"
+  depends_on = [
+    module.gh_oidc_roles
+  ]
+}
+
 data "aws_iam_policy" "admin" {
   name = "AdministratorAccess"
   depends_on = [
@@ -47,6 +70,14 @@ data "aws_iam_policy" "admin" {
 
 resource "aws_iam_role_policy_attachment" "admin" {
   role       = local.admin_name
+  policy_arn = data.aws_iam_policy.admin.arn
+  depends_on = [
+    module.gh_oidc_roles
+  ]
+}
+
+resource "aws_iam_role_policy_attachment" "sc_admin" {
+  role       = local.sc_admin_name
   policy_arn = data.aws_iam_policy.admin.arn
   depends_on = [
     module.gh_oidc_roles

--- a/terragrunt/log_archive/main/terragrunt.hcl
+++ b/terragrunt/log_archive/main/terragrunt.hcl
@@ -1,0 +1,3 @@
+include {
+  path = find_in_parent_folders()
+}

--- a/terragrunt/log_archive/terragrunt.hcl
+++ b/terragrunt/log_archive/terragrunt.hcl
@@ -1,0 +1,47 @@
+
+locals {
+  account_id       = "274536870005"
+  env              = "production"
+  product_name     = "cds-aft-log-archive"
+  cost_center_code = "${local.product_name}-${local.env}"
+}
+
+# DO NOT CHANGE ANYTHING BELOW HERE UNLESS YOU KNOW WHAT YOU ARE DOING
+
+inputs = {
+  account_id   = local.account_id
+  env          = local.env
+  product_name = local.product_name
+  region       = "ca-central-1"
+  billing_code = local.cost_center_code
+}
+
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite"
+  contents  = file("../common/provider.tf")
+
+}
+
+generate "common_variables" {
+  path      = "common_variables.tf"
+  if_exists = "overwrite"
+  contents  = file("../common/common_variables.tf")
+}
+
+remote_state {
+  backend = "s3"
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+  config = {
+    encrypt             = true
+    bucket              = "${local.cost_center_code}-tf"
+    dynamodb_table      = "terraform-state-lock-dynamo"
+    region              = "ca-central-1"
+    key                 = "${path_relative_to_include()}/terraform.tfstate"
+    s3_bucket_tags      = { CostCenter : local.cost_center_code }
+    dynamodb_table_tags = { CostCenter : local.cost_center_code }
+  }
+}


### PR DESCRIPTION
# Summary | Résumé

Removes the Sentinel Connectors OIDC for the audit account as we don't
need them.

Adds them instead to the log archive which is where the GD findings go.

Modifies the Workflows for terraform plan and action so that we aren't just copy and pasting stuff all over the place. 


**Please Note:** The OIDC Roles have been applied locally and so the changes will not show up in this PR.
