### PR TITLE
fix: Split out AFT plan from reg workflow

### DIFF
--- a/.github/workflows/tf-plan-aft.yml
+++ b/.github/workflows/tf-plan-aft.yml
@@ -1,0 +1,49 @@
+name: Terraform aft plan
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "terragrunt/org_account/aft/**"
+      - ".github/workflows/tf-plan-aft.yml"
+      - ".github/workflows/tf-apply.yml"
+env:
+  AWS_REGION: "ca-central-1"
+  TERRAFORM_VERSION: 1.1.7
+  TERRAGRUNT_VERSION: 0.36.3
+  CONFTEST_VERSION: 0.30.0
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+  actions: write
+  checks: write
+  statuses: write
+
+jobs:
+  terraform-plan-aft-account:
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: setup terraform tools
+        uses: cds-snc/terraform-tools-setup@v1
+
+      - name: Configure aws credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@master
+        with:
+          role-to-assume: arn:aws:iam::659087519042:role/CDSLZTerraformAdminPlanRole
+          role-session-name: 659087519042-aft-CDSLZTerraformAdminPlanRole-plan
+          aws-region: ca-central-1
+
+      - name: Terraform Plan for org_account/aft
+        # I have no idea if this will work.
+        uses: cds-snc/terraform-plan@v2
+        with:
+          comment-delete: true
+          comment-title: Plan for org_account/aft
+          directory: ./terragrunt/org_account/aft
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          terragrunt: true

--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -47,11 +47,6 @@ jobs:
             role: CDSLZTerraformReadOnlyRole
             lz_webhook_key: LZ_CHANNEL_WEBHOOK
 
-          - account_folder: org_account
-            module: aft
-            account: 659087519042
-            role: CDSLZTerraformAdminPlanRole
-
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
# Summary | Résumé

The AFT plan was running all the time and causing lock issues because it
ran on every commit.

The AFT plan will now only run if the workflow files have changed or the
code in the folder has changed.


