### PR TITLE
feat: manage organization settings through TF

### DIFF
--- a/terragrunt/org_account/main/main.tf
+++ b/terragrunt/org_account/main/main.tf
@@ -18,3 +18,21 @@ resource "aws_servicecatalog_principal_portfolio_association" "aft_role_account_
   portfolio_id  = data.aws_servicecatalog_portfolio.account_factory.id
   principal_arn = data.aws_iam_role.aft_execution_role.arn
 }
+
+resource "aws_organizations_organization" "org_config" {
+
+  aws_service_access_principals = [
+    "cloudtrail.amazonaws.com", # Enabled by Control Tower
+    "config.amazonaws.com", # Enabled by Control Tower
+    "sso.amazonaws.com", # Enabled by Control Tower
+    "controltower.amazonaws.com", # Enabled by Control Tower
+    "guardduty.amazonaws.com",
+    "securityhub.amazonaws.com"
+  ]
+
+  enabled_policy_types = [
+    "SERVICE_CONTROL_POLICY"
+  ]
+
+  feature_set = "ALL"
+}

--- a/terragrunt/org_account/main/main.tf
+++ b/terragrunt/org_account/main/main.tf
@@ -22,9 +22,9 @@ resource "aws_servicecatalog_principal_portfolio_association" "aft_role_account_
 resource "aws_organizations_organization" "org_config" {
 
   aws_service_access_principals = [
-    "cloudtrail.amazonaws.com", # Enabled by Control Tower
-    "config.amazonaws.com", # Enabled by Control Tower
-    "sso.amazonaws.com", # Enabled by Control Tower
+    "cloudtrail.amazonaws.com",   # Enabled by Control Tower
+    "config.amazonaws.com",       # Enabled by Control Tower
+    "sso.amazonaws.com",          # Enabled by Control Tower
     "controltower.amazonaws.com", # Enabled by Control Tower
     "guardduty.amazonaws.com",
     "securityhub.amazonaws.com"


### PR DESCRIPTION
# Summary | Résumé

Added an aws_organizations_organization resource to manage what services
are available in the org.

This was imported locally, the only services that weren't already
enabled were guardduty and security hub


