### PR TITLE
feat: enable guardduty in log archive

### DIFF
--- a/terragrunt/log_archive/main/guardduty.tf
+++ b/terragrunt/log_archive/main/guardduty.tf
@@ -1,0 +1,79 @@
+provider "aws" {
+  region = "us-east-1"
+  alias  = "us-east-1"
+}
+
+provider "aws" {
+  region = "us-west-2"
+  alias  = "us-west-2"
+}
+
+module "guardduty_ca_central_1" {
+  source = "../modules/guardduty"
+
+  publishing_bucket_arn = module.publishing_bucket.s3_bucket_arn
+  kms-key_arn           = aws_kms_key.cds_sentinel_guard_duty_key.arn
+
+  billing_tag_value = var.billing_code
+}
+
+module "guardduty_ca_central_1" {
+  source   = "../modules/guardduty"
+  provider = aws.us-east-1
+
+  publishing_bucket_arn = module.publishing_bucket.s3_bucket_arn
+  kms-key_arn           = aws_kms_key.cds_sentinel_guard_duty_key.arn
+
+  billing_tag_value = var.billing_code
+}
+
+module "guardduty_ca_central_1" {
+  source   = "../modules/guardduty"
+  provider = aws.us-east-2
+
+  publishing_bucket_arn = module.publishing_bucket.s3_bucket_arn
+  kms-key_arn           = aws_kms_key.cds_sentinel_guard_duty_key.arn
+
+  billing_tag_value = var.billing_code
+}
+
+module "publishing_bucket" {
+  source = "github.com/cds-snc/terraform-modules?v2.0.4//S3"
+
+
+  logging = {
+    target_bucket = module.publishing_log_bucket.s3_bucket_id
+  }
+
+  billing_tag_value = var.billing_code
+}
+
+module "publishing_log_bucket" {
+  source = "github.com/cds-snc/terraform-modules?v2.0.4//S3_log_bucket"
+
+  billing_tag_value = var.billing_code
+}
+
+data "aws_iam_policy_document" "cds_sentinel_guard_duty_logs_kms_inline" {
+  statement {
+    sid = "1"
+
+    actions   = ["kms:GenerateDataKey"]
+    resources = ["arn:aws:kms:ca-central-1:${var.account_id}:key/*"]
+    principals {
+      type        = "Service"
+      identifiers = ["guardduty.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_kms_key" "cds_sentinel_guard_duty_key" {
+  description             = "CDS Sentinel GuardDuty KMS"
+  deletion_window_in_days = 7
+  policy                  = data.aws_iam_policy_document.cds_sentinel_guard_duty_logs_kms_inline.json
+}
+
+resource "aws_kms_alias" "cds_sentinel_guard_duty_key" {
+  name          = "alias/guardduty-key"
+  target_key_id = aws_kms_key.cds_sentinel_guard_duty_key.key_id
+}

--- a/terragrunt/log_archive/modules/guardduty/input.tf
+++ b/terragrunt/log_archive/modules/guardduty/input.tf
@@ -1,0 +1,41 @@
+variable "billing_tag_key" {
+  description = "(Optional, default 'CostCentre') The name of the billing tag"
+  type        = string
+  default     = "CostCentre"
+}
+
+variable "billing_tag_value" {
+  description = "(Required) The value of the billing tag"
+  type        = string
+}
+
+variable "publishing_frequency" {
+  description = "Specifies the frequency of notifications sent for subsequent finding occurrences."
+  type        = string
+  default     = "FIFTEEN_MINUTES"
+}
+
+variable "tags" {
+  description = "Specifies object tags key and value. This applies to all resources created by this module."
+  type        = map(string)
+  default     = {}
+}
+
+variable "publishing_bucket_arn" {
+  description = "(Required) The ARN of the S3 bucket to publish findings to"
+  type        = string
+}
+
+variable "kms_key_arn" {
+  description = "(Required) The KMS key to encrypt findings in the S3 bucket"
+  type        = string
+}
+
+variable "tags" {
+  description = <<EOF
+  (Optional) Key-value map of resource tags. If configured with a provider default_tags configuration block present,
+  tags with matching keys will overwrite those defined at the provider-level."
+  EOF
+  type        = map(string)
+  default     = {}
+}

--- a/terragrunt/log_archive/modules/guardduty/main.tf
+++ b/terragrunt/log_archive/modules/guardduty/main.tf
@@ -1,0 +1,45 @@
+
+
+# GuardDuty Detector in the Delegated admin account
+resource "aws_guardduty_detector" "this" {
+
+  enable                       = true
+  finding_publishing_frequency = var.publishing_frequency
+
+  # Additional setting to turn on S3 Protection
+  datasources {
+    s3_logs {
+      enable = true
+    }
+  }
+  tags = merge(var.tags, local.common_tags)
+}
+
+# Organization GuardDuty configuration in the Delegated admin account
+resource "aws_guardduty_organization_configuration" "this" {
+
+  auto_enable = true
+  detector_id = aws_guardduty_detector.this.id
+
+  # Additional setting to turn on S3 Protection
+  datasources {
+    s3_logs {
+      auto_enable = true
+    }
+  }
+}
+
+# GuardDuty Publishing destination in the Delegated admin account
+resource "aws_guardduty_publishing_destination" "pub_dest" {
+
+  detector_id     = aws_guardduty_detector.this.id
+  destination_arn = var.publishing_bucket_arn
+  kms_key_arn     = var.kms_key_arn
+}
+
+locals {
+  common_tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = "true"
+  }
+}


### PR DESCRIPTION
# Summary | Résumé

Turns on guardduty and detectors in each region used in our landing zone
Sends all data to a single bucket that we can later configure to send to
our SIEM

I went with a local module instead of the ones in the
github.com/cds-snc/terraform-modules repo since we won't be re-using
these and I didn't want to bother with setting up the infra for the root
account to assume roles in all child accounts.


