### PR TITLE
fix: remove fail_fast on apply

### DIFF
--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         include:
 


### PR DESCRIPTION
# Summary | Résumé

Fail fast was causing issues as applys would fail and then it would cause locks on all the other states. 

State buckets are in a bad state so this may fail but this is the first step to trying to fix this thing.
