### PR TITLE
feat: enable guardduty in org account and invite

### DIFF
--- a/terragrunt/log_archive/main/guardduty.tf
+++ b/terragrunt/log_archive/main/guardduty.tf
@@ -193,8 +193,8 @@ locals {
   account_ids = [
     "137554749751", # AFT-Manamgement
     "886481071419", # Audit
-    "034163289675",  # ct-test-account
-    "659087519042" # Org Account must be enabled in master account first
+    "034163289675", # ct-test-account
+    "659087519042"  # Org Account must be enabled in master account first
   ]
 }
 

--- a/terragrunt/log_archive/main/guardduty.tf
+++ b/terragrunt/log_archive/main/guardduty.tf
@@ -156,7 +156,7 @@ resource "aws_guardduty_organization_configuration" "config_us_east_1" {
   provider = aws.us-east-1
 
   auto_enable = true
-  detector_id = aws_guardduty_detector.detector.id
+  detector_id = aws_guardduty_detector.detector_us_east_1.id
 
   # Additional setting to turn on S3 Protection
   datasources {
@@ -171,7 +171,7 @@ resource "aws_guardduty_organization_configuration" "config_us_west_2" {
   provider = aws.us-west-2
 
   auto_enable = true
-  detector_id = aws_guardduty_detector.detector.id
+  detector_id = aws_guardduty_detector.detector_us_west_2.id
 
   # Additional setting to turn on S3 Protection
   datasources {
@@ -193,8 +193,8 @@ locals {
   account_ids = [
     "137554749751", # AFT-Manamgement
     "886481071419", # Audit
-    "034163289675"  # ct-test-account
-    # "659087519042", # Org Account must be enabled in master account first
+    "034163289675",  # ct-test-account
+    "659087519042" # Org Account must be enabled in master account first
   ]
 }
 

--- a/terragrunt/org_account/main/guardduty.tf
+++ b/terragrunt/org_account/main/guardduty.tf
@@ -19,3 +19,46 @@ resource "aws_guardduty_organization_admin_account" "gd_admin_us_west_2" {
   depends_on       = [aws_organizations_organization.org_config]
   admin_account_id = local.admin_account
 }
+
+# GuardDuty Detector in the org admin account
+resource "aws_guardduty_detector" "detector_ca_central_1" {
+
+  enable                       = true
+  finding_publishing_frequency = "FIFTEEN_MINUTES"
+
+  # Additional setting to turn on S3 Protection
+  datasources {
+    s3_logs {
+      enable = true
+    }
+  }
+}
+
+resource "aws_guardduty_detector" "detector_us_east_1" {
+  provider = aws.us-east-1
+
+  enable                       = true
+  finding_publishing_frequency = "FIFTEEN_MINUTES"
+
+  # Additional setting to turn on S3 Protection
+  datasources {
+    s3_logs {
+      enable = true
+    }
+  }
+}
+
+resource "aws_guardduty_detector" "detector_us_west_2" {
+
+  provider = aws.us-west-2
+
+  enable                       = true
+  finding_publishing_frequency = "FIFTEEN_MINUTES"
+
+  # Additional setting to turn on S3 Protection
+  datasources {
+    s3_logs {
+      enable = true
+    }
+  }
+}


### PR DESCRIPTION
# Summary | Résumé

- also configures the detectors for us_east_1 and us_west_2
- all of the changes in the log_archive account were automatically
  created
- changes to resources in the org level account  are expected since all
  I did was create the resources and import them.

