### PR TITLE
feat: add roles to assume into in child accounts

### DIFF
--- a/terragrunt/aft/main/assume_roles.tf
+++ b/terragrunt/aft/main/assume_roles.tf
@@ -10,9 +10,17 @@ module "assume_plan_role" {
 
 }
 
-resource "aws_iam_role_policy_attachment" "assume_admin" {
-  role       = module.assume_apply_role.role_name
-  policy_arn = data.aws_iam_policy.admin.arn
+module "attach_tf_plan_policy_assume" {
+  source            = "github.com/cds-snc/terraform-modules?ref=v2.0.2//attach_tf_plan_policy"
+  account_id        = data.aws_caller_identity.current.account_id
+  role_name         = "assume_plan"
+  bucket_name       = "${var.billing_code}-tf"
+  lock_table_name   = "terraform-state-lock-dynamo"
+  billing_tag_value = var.billing_code
+  policy_name       = "AssumePlan"
+  depends_on = [
+    module.gh_oidc_roles
+  ]
 }
 
 # Apply Assume Role
@@ -26,15 +34,7 @@ module "assume_apply_role" {
   billing_tag_value     = var.billing_code
 }
 
-module "attach_tf_plan_policy_assume" {
-  source            = "github.com/cds-snc/terraform-modules?ref=v2.0.2//attach_tf_plan_policy"
-  account_id        = data.aws_caller_identity.current.account_id
-  role_name         = local.plan_name
-  bucket_name       = "${var.billing_code}-tf"
-  lock_table_name   = "terraform-state-lock-dynamo"
-  billing_tag_value = var.billing_code
-  policy_name       = "AssumePlan"
-  depends_on = [
-    module.gh_oidc_roles
-  ]
+resource "aws_iam_role_policy_attachment" "assume_admin" {
+  role       = module.assume_apply_role.role_name
+  policy_arn = data.aws_iam_policy.admin.arn
 }

--- a/terragrunt/aft/main/assume_roles.tf
+++ b/terragrunt/aft/main/assume_roles.tf
@@ -1,4 +1,4 @@
- 
+
 # Plan Assume Role
 module "assume_plan_role" {
   source                = "../../modules/assume_role"

--- a/terragrunt/aft/main/assume_roles.tf
+++ b/terragrunt/aft/main/assume_roles.tf
@@ -1,0 +1,40 @@
+ 
+# Plan Assume Role
+module "assume_plan_role" {
+  source                = "../../modules/assume_role"
+  role_name             = "assume_plan"
+  org_account           = var.org_account
+  org_account_role_name = local.plan_name
+  assume_policy_name    = "AssumePlanRole"
+  billing_tag_value     = var.billing_code
+
+}
+
+resource "aws_iam_role_policy_attachment" "assume_admin" {
+  role       = module.assume_apply_role.role_name
+  policy_arn = data.aws_iam_policy.admin.arn
+}
+
+# Apply Assume Role
+
+module "assume_apply_role" {
+  source                = "../../modules/assume_role"
+  role_name             = "assume_apply"
+  org_account           = var.org_account
+  org_account_role_name = local.admin_name
+  assume_policy_name    = "AssumeApplyRole"
+  billing_tag_value     = var.billing_code
+}
+
+module "attach_tf_plan_policy_assume" {
+  source            = "github.com/cds-snc/terraform-modules?ref=v2.0.2//attach_tf_plan_policy"
+  account_id        = data.aws_caller_identity.current.account_id
+  role_name         = local.plan_name
+  bucket_name       = "${var.billing_code}-tf"
+  lock_table_name   = "terraform-state-lock-dynamo"
+  billing_tag_value = var.billing_code
+  policy_name       = "AssumePlan"
+  depends_on = [
+    module.gh_oidc_roles
+  ]
+}

--- a/terragrunt/audit/main/assume_roles.tf
+++ b/terragrunt/audit/main/assume_roles.tf
@@ -10,9 +10,17 @@ module "assume_plan_role" {
 
 }
 
-resource "aws_iam_role_policy_attachment" "assume_admin" {
-  role       = module.assume_apply_role.role_name
-  policy_arn = data.aws_iam_policy.admin.arn
+module "attach_tf_plan_policy_assume" {
+  source            = "github.com/cds-snc/terraform-modules?ref=v2.0.2//attach_tf_plan_policy"
+  account_id        = data.aws_caller_identity.current.account_id
+  role_name         = "assume_plan"
+  bucket_name       = "${var.billing_code}-tf"
+  lock_table_name   = "terraform-state-lock-dynamo"
+  billing_tag_value = var.billing_code
+  policy_name       = "AssumePlan"
+  depends_on = [
+    module.gh_oidc_roles
+  ]
 }
 
 # Apply Assume Role
@@ -26,15 +34,7 @@ module "assume_apply_role" {
   billing_tag_value     = var.billing_code
 }
 
-module "attach_tf_plan_policy_assume" {
-  source            = "github.com/cds-snc/terraform-modules?ref=v2.0.2//attach_tf_plan_policy"
-  account_id        = data.aws_caller_identity.current.account_id
-  role_name         = local.plan_name
-  bucket_name       = "${var.billing_code}-tf"
-  lock_table_name   = "terraform-state-lock-dynamo"
-  billing_tag_value = var.billing_code
-  policy_name       = "AssumePlan"
-  depends_on = [
-    module.gh_oidc_roles
-  ]
+resource "aws_iam_role_policy_attachment" "assume_admin" {
+  role       = module.assume_apply_role.role_name
+  policy_arn = data.aws_iam_policy.admin.arn
 }

--- a/terragrunt/audit/main/assume_roles.tf
+++ b/terragrunt/audit/main/assume_roles.tf
@@ -1,4 +1,4 @@
- 
+
 # Plan Assume Role
 module "assume_plan_role" {
   source                = "../../modules/assume_role"

--- a/terragrunt/audit/main/assume_roles.tf
+++ b/terragrunt/audit/main/assume_roles.tf
@@ -1,0 +1,40 @@
+ 
+# Plan Assume Role
+module "assume_plan_role" {
+  source                = "../../modules/assume_role"
+  role_name             = "assume_plan"
+  org_account           = var.org_account
+  org_account_role_name = local.plan_name
+  assume_policy_name    = "AssumePlanRole"
+  billing_tag_value     = var.billing_code
+
+}
+
+resource "aws_iam_role_policy_attachment" "assume_admin" {
+  role       = module.assume_apply_role.role_name
+  policy_arn = data.aws_iam_policy.admin.arn
+}
+
+# Apply Assume Role
+
+module "assume_apply_role" {
+  source                = "../../modules/assume_role"
+  role_name             = "assume_apply"
+  org_account           = var.org_account
+  org_account_role_name = local.admin_name
+  assume_policy_name    = "AssumeApplyRole"
+  billing_tag_value     = var.billing_code
+}
+
+module "attach_tf_plan_policy_assume" {
+  source            = "github.com/cds-snc/terraform-modules?ref=v2.0.2//attach_tf_plan_policy"
+  account_id        = data.aws_caller_identity.current.account_id
+  role_name         = local.plan_name
+  bucket_name       = "${var.billing_code}-tf"
+  lock_table_name   = "terraform-state-lock-dynamo"
+  billing_tag_value = var.billing_code
+  policy_name       = "AssumePlan"
+  depends_on = [
+    module.gh_oidc_roles
+  ]
+}

--- a/terragrunt/audit/main/main.tf
+++ b/terragrunt/audit/main/main.tf
@@ -52,6 +52,7 @@ resource "aws_iam_role_policy_attachment" "admin" {
     module.gh_oidc_roles
   ]
 }
+<<<<<<< HEAD
 
 # Plan Assume Role
 module "assume_plan_role" {
@@ -92,3 +93,5 @@ module "attach_tf_plan_policy_assume" {
     module.gh_oidc_roles
   ]
 }
+=======
+>>>>>>> d341ee2 (feat: add roles to assume into in child accounts)

--- a/terragrunt/audit/main/main.tf
+++ b/terragrunt/audit/main/main.tf
@@ -52,46 +52,4 @@ resource "aws_iam_role_policy_attachment" "admin" {
     module.gh_oidc_roles
   ]
 }
-<<<<<<< HEAD
 
-# Plan Assume Role
-module "assume_plan_role" {
-  source                = "../../modules/assume_role"
-  role_name             = "assume_plan"
-  org_account           = var.org_account
-  org_account_role_name = local.plan_name
-  assume_policy_name    = "AssumePlanRole"
-  billing_tag_value     = var.billing_code
-
-}
-
-resource "aws_iam_role_policy_attachment" "assume_admin" {
-  role       = module.assume_apply_role.role_name
-  policy_arn = data.aws_iam_policy.admin.arn
-}
-
-# Apply Assume Role
-
-module "assume_apply_role" {
-  source                = "../../modules/assume_role"
-  role_name             = "assume_apply"
-  org_account           = var.org_account
-  org_account_role_name = local.admin_name
-  assume_policy_name    = "AssumeApplyRole"
-  billing_tag_value     = var.billing_code
-}
-
-module "attach_tf_plan_policy_assume" {
-  source            = "github.com/cds-snc/terraform-modules?ref=v2.0.2//attach_tf_plan_policy"
-  account_id        = data.aws_caller_identity.current.account_id
-  role_name         = "assume_plan"
-  bucket_name       = "${var.billing_code}-tf"
-  lock_table_name   = "terraform-state-lock-dynamo"
-  billing_tag_value = var.billing_code
-  policy_name       = "AssumePlan"
-  depends_on = [
-    module.gh_oidc_roles
-  ]
-}
-=======
->>>>>>> d341ee2 (feat: add roles to assume into in child accounts)

--- a/terragrunt/log_archive/main/assume_roles.tf
+++ b/terragrunt/log_archive/main/assume_roles.tf
@@ -10,9 +10,17 @@ module "assume_plan_role" {
 
 }
 
-resource "aws_iam_role_policy_attachment" "assume_admin" {
-  role       = module.assume_apply_role.role_name
-  policy_arn = data.aws_iam_policy.admin.arn
+module "attach_tf_plan_policy_assume" {
+  source            = "github.com/cds-snc/terraform-modules?ref=v2.0.2//attach_tf_plan_policy"
+  account_id        = data.aws_caller_identity.current.account_id
+  role_name         = "assume_plan"
+  bucket_name       = "${var.billing_code}-tf"
+  lock_table_name   = "terraform-state-lock-dynamo"
+  billing_tag_value = var.billing_code
+  policy_name       = "AssumePlan"
+  depends_on = [
+    module.gh_oidc_roles
+  ]
 }
 
 # Apply Assume Role
@@ -26,15 +34,7 @@ module "assume_apply_role" {
   billing_tag_value     = var.billing_code
 }
 
-module "attach_tf_plan_policy_assume" {
-  source            = "github.com/cds-snc/terraform-modules?ref=v2.0.2//attach_tf_plan_policy"
-  account_id        = data.aws_caller_identity.current.account_id
-  role_name         = local.plan_name
-  bucket_name       = "${var.billing_code}-tf"
-  lock_table_name   = "terraform-state-lock-dynamo"
-  billing_tag_value = var.billing_code
-  policy_name       = "AssumePlan"
-  depends_on = [
-    module.gh_oidc_roles
-  ]
+resource "aws_iam_role_policy_attachment" "assume_admin" {
+  role       = module.assume_apply_role.role_name
+  policy_arn = data.aws_iam_policy.admin.arn
 }

--- a/terragrunt/log_archive/main/assume_roles.tf
+++ b/terragrunt/log_archive/main/assume_roles.tf
@@ -1,4 +1,4 @@
- 
+
 # Plan Assume Role
 module "assume_plan_role" {
   source                = "../../modules/assume_role"

--- a/terragrunt/log_archive/main/assume_roles.tf
+++ b/terragrunt/log_archive/main/assume_roles.tf
@@ -1,0 +1,40 @@
+ 
+# Plan Assume Role
+module "assume_plan_role" {
+  source                = "../../modules/assume_role"
+  role_name             = "assume_plan"
+  org_account           = var.org_account
+  org_account_role_name = local.plan_name
+  assume_policy_name    = "AssumePlanRole"
+  billing_tag_value     = var.billing_code
+
+}
+
+resource "aws_iam_role_policy_attachment" "assume_admin" {
+  role       = module.assume_apply_role.role_name
+  policy_arn = data.aws_iam_policy.admin.arn
+}
+
+# Apply Assume Role
+
+module "assume_apply_role" {
+  source                = "../../modules/assume_role"
+  role_name             = "assume_apply"
+  org_account           = var.org_account
+  org_account_role_name = local.admin_name
+  assume_policy_name    = "AssumeApplyRole"
+  billing_tag_value     = var.billing_code
+}
+
+module "attach_tf_plan_policy_assume" {
+  source            = "github.com/cds-snc/terraform-modules?ref=v2.0.2//attach_tf_plan_policy"
+  account_id        = data.aws_caller_identity.current.account_id
+  role_name         = local.plan_name
+  bucket_name       = "${var.billing_code}-tf"
+  lock_table_name   = "terraform-state-lock-dynamo"
+  billing_tag_value = var.billing_code
+  policy_name       = "AssumePlan"
+  depends_on = [
+    module.gh_oidc_roles
+  ]
+}


### PR DESCRIPTION
# Summary | Résumé

- copies the pattern from the audit account and adds roles for the
  AFT-Maintenance Account and the Log_Archive account

This is PR 1 of 2, the next one will be adding roles to the org account that allows it to assume into these roles

