### PR TITLE
fix: enable sh first before inviting

### DIFF
--- a/terragrunt/org_account/main/securityhub.tf
+++ b/terragrunt/org_account/main/securityhub.tf
@@ -23,10 +23,16 @@ resource "aws_securityhub_standards_subscription" "cis_aws_foundations_benchmark
 
 # invites
 
+resource "aws_securityhub_account" "audit" {
+  provider = aws.audit_log
+}
+
 resource "aws_securityhub_member" "audit" {
   account_id = "886481071419"
   email      = "aws-cloud-pb-ct+sh@cds-snc.ca"
   invite     = true
+
+  depends_on = [aws_securityhub_account.audit]
 }
 
 resource "aws_securityhub_invite_accepter" "audit" {
@@ -35,10 +41,16 @@ resource "aws_securityhub_invite_accepter" "audit" {
   master_id  = aws_securityhub_member.audit.master_id
 }
 
+resource "aws_securityhub_account" "log_archive" {
+  provider = aws.log_archive
+}
+
 resource "aws_securityhub_member" "log_archive" {
   account_id = "274536870005"
   email      = "aws-cloud-pb-ct+sh@cds-snc.ca"
   invite     = true
+
+  depends_on = [aws_securityhub_account.log_archive]
 }
 
 resource "aws_securityhub_invite_accepter" "log_archive" {
@@ -47,10 +59,16 @@ resource "aws_securityhub_invite_accepter" "log_archive" {
   master_id  = aws_securityhub_member.log_archive.master_id
 }
 
+resource "aws_securityhub_account" "aft_management" {
+  provider = aws.aft_management
+}
+
 resource "aws_securityhub_member" "aft_management" {
   account_id = "137554749751"
   email      = "aws-cloud-pb-ct+sh@cds-snc.ca"
   invite     = true
+
+  depends_on = [aws_securityhub_account.aft_management]
 }
 
 resource "aws_securityhub_invite_accepter" "aft_management" {


### PR DESCRIPTION
# Summary | Résumé

last merge failed I'm assuming it's because SH needs to be enabled first
and that this is a different pattern from Guardduty that gets enabled
when you invite.


