### PR TITLE
feat: invite centrally managed accounts

### DIFF
--- a/terragrunt/org_account/main/securityhub.tf
+++ b/terragrunt/org_account/main/securityhub.tf
@@ -23,7 +23,7 @@ resource "aws_securityhub_standards_subscription" "cis_aws_foundations_benchmark
 
 # invites
 
-resource "aws_securityhub_acocunt" "org" {}
+resource "aws_securityhub_account" "org" {}
 
 resource "aws_securityhub_member" "org" {
   provider = aws.log_archive

--- a/terragrunt/org_account/main/securityhub.tf
+++ b/terragrunt/org_account/main/securityhub.tf
@@ -23,15 +23,66 @@ resource "aws_securityhub_standards_subscription" "cis_aws_foundations_benchmark
 
 # invites
 
+resource "aws_securityhub_acocunt" "org" {}
+
+resource "aws_securityhub_member" "org" {
+  provider = aws.log_archive
+
+  account_id = var.org_account
+
+  email  = "aws-cloud-pb-ct+sh@cds-snc.ca"
+  invite = true
+
+  depends_on = [aws_securityhub_account.org]
+
+}
+
+resource "aws_securityhub_invite_accepter" "org" {
+  master_id  = aws_securityhub_member.org.master_id
+  depends_on = [aws_securityhub_member.org]
+}
+
+# audit 
 resource "aws_securityhub_account" "audit" {
   provider = aws.audit_log
 }
 
-
-resource "aws_securityhub_account" "log_archive" {
+resource "aws_securityhub_member" "audit" {
   provider = aws.log_archive
+
+  account_id = "886481071419"
+  email      = "aws-cloud-pb-ct+sh@cds-snc.ca"
+  invite     = true
+
+  depends_on = [aws_securityhub_account.audit]
 }
+
+resource "aws_securityhub_invite_accepter" "audit" {
+  provider   = aws.audit_log
+  master_id  = aws_securityhub_member.audit.master_id
+  depends_on = [aws_securityhub_member.audit]
+}
+
+# aft_management
+
 
 resource "aws_securityhub_account" "aft_management" {
   provider = aws.aft_management
 }
+
+resource "aws_securityhub_member" "aft_management" {
+  provider = aws.log_archive
+
+  account_id = "137554749751"
+  email      = "aws-cloud-pb-ct+sh@cds-snc.ca"
+  invite     = true
+
+  depends_on = [aws_securityhub_account.aft_management]
+}
+
+resource "aws_securityhub_invite_accepter" "aft_management" {
+  provider   = aws.aft_management
+  master_id  = aws_securityhub_member.aft_management.master_id
+  depends_on = [aws_securityhub_member.aft_management]
+}
+


### PR DESCRIPTION
# Summary | Résumé

I think I didn't have it working properly before and that inviting the
log archive which is the delegated admin account was causing the issues
not inviting the accounts.

This should hopefully work, but maybe not...

