### PR TITLE
fix: remove org account

### DIFF
--- a/terragrunt/org_account/main/securityhub.tf
+++ b/terragrunt/org_account/main/securityhub.tf
@@ -19,29 +19,6 @@ resource "aws_securityhub_standards_subscription" "cis_aws_foundations_benchmark
   depends_on = [aws_securityhub_organization_admin_account.admin_account]
 }
 
-
-
-# invites
-
-resource "aws_securityhub_account" "org" {}
-
-resource "aws_securityhub_member" "org" {
-  provider = aws.log_archive
-
-  account_id = var.org_account
-
-  email  = "aws-cloud-pb-ct+sh@cds-snc.ca"
-  invite = true
-
-  depends_on = [aws_securityhub_account.org]
-
-}
-
-resource "aws_securityhub_invite_accepter" "org" {
-  master_id  = aws_securityhub_member.org.master_id
-  depends_on = [aws_securityhub_member.org]
-}
-
 # audit 
 resource "aws_securityhub_account" "audit" {
   provider = aws.audit_log


### PR DESCRIPTION
# Summary | Résumé

The org account was click-opsed because the previous PR failed.


