### PR TITLE
refactor: security hub into a module

### DIFF
--- a/terragrunt/modules/assume_role/main.tf
+++ b/terragrunt/modules/assume_role/main.tf
@@ -14,10 +14,11 @@ data "aws_iam_policy_document" "this" {
   statement {
     actions = ["sts:AssumeRole"]
     principals {
-      type        = "AWS"
+      type = "AWS"
       identifiers = [
         "arn:aws:iam::${var.org_account}:role/${var.org_account_role_name}",
-        "arn:aws:iam::${var.org_account}:user/CalvinRodo"] # Will only be here as long as I need to debug TF locally.
+        "arn:aws:iam::${var.org_account}:user/CalvinRodo"
+      ] # Will only be here as long as I need to debug TF locally.
     }
   }
 }

--- a/terragrunt/modules/assume_role/main.tf
+++ b/terragrunt/modules/assume_role/main.tf
@@ -15,7 +15,9 @@ data "aws_iam_policy_document" "this" {
     actions = ["sts:AssumeRole"]
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::${var.org_account}:role/${var.org_account_role_name}"]
+      identifiers = [
+        "arn:aws:iam::${var.org_account}:role/${var.org_account_role_name}",
+        "arn:aws:iam::${var.org_account}:user/CalvinRodo"] # Will only be here as long as I need to debug TF locally.
     }
   }
 }

--- a/terragrunt/modules/existing_security_hub_member/input.tf
+++ b/terragrunt/modules/existing_security_hub_member/input.tf
@@ -1,4 +1,4 @@
 variable "email" {
-  type = string
+  type        = string
   description = "email to send invitation to"
 }

--- a/terragrunt/modules/existing_security_hub_member/input.tf
+++ b/terragrunt/modules/existing_security_hub_member/input.tf
@@ -1,0 +1,4 @@
+variable "email" {
+  type = string
+  description = "email to send invitation to"
+}

--- a/terragrunt/modules/existing_security_hub_member/main.tf
+++ b/terragrunt/modules/existing_security_hub_member/main.tf
@@ -14,13 +14,13 @@ resource "aws_securityhub_member" "this" {
 
   account_id = data.aws_caller_identity.member.account_id
 
-  email      = var.email
-  invite     = true
+  email  = var.email
+  invite = true
 
   depends_on = [aws_securityhub_account.this]
 
   lifecycle { # Known bug https://github.com/hashicorp/terraform-provider-aws/issues/24320
-      ignore_changes = [email]
+    ignore_changes = [email]
   }
 }
 

--- a/terragrunt/modules/existing_security_hub_member/main.tf
+++ b/terragrunt/modules/existing_security_hub_member/main.tf
@@ -1,0 +1,32 @@
+
+# Enable Security Hub
+resource "aws_securityhub_account" "this" {
+  provider = aws.member
+}
+
+data "aws_caller_identity" "member" {
+  provider = aws.member
+}
+
+# Add the account as a delegated member of security hub
+resource "aws_securityhub_member" "this" {
+  provider = aws.admin
+
+  account_id = data.aws_caller_identity.member.account_id
+
+  email      = var.email
+  invite     = true
+
+  depends_on = [aws_securityhub_account.this]
+
+  lifecycle { # Known bug https://github.com/hashicorp/terraform-provider-aws/issues/24320
+      ignore_changes = [email]
+  }
+}
+
+# Accept the invitiation
+resource "aws_securityhub_invite_accepter" "this" {
+  provider   = aws.member
+  master_id  = aws_securityhub_member.this.master_id
+  depends_on = [aws_securityhub_member.this]
+}

--- a/terragrunt/modules/existing_security_hub_member/providers.tf
+++ b/terragrunt/modules/existing_security_hub_member/providers.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_providers  {
-    aws = { 
-      source = "hashicorp/aws"
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
       configuration_aliases = [aws.admin, aws.member]
     }
   }

--- a/terragrunt/modules/existing_security_hub_member/providers.tf
+++ b/terragrunt/modules/existing_security_hub_member/providers.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers  {
+    aws = { 
+      source = "hashicorp/aws"
+      configuration_aliases = [aws.admin, aws.member]
+    }
+  }
+}

--- a/terragrunt/org_account/main/securityhub.tf
+++ b/terragrunt/org_account/main/securityhub.tf
@@ -22,29 +22,29 @@ resource "aws_securityhub_standards_subscription" "cis_aws_foundations_benchmark
 module "org" {
   source = "../../modules/existing_security_hub_member"
   providers = {
-    aws.admin = aws.log_archive
+    aws.admin  = aws.log_archive
     aws.member = aws
   }
 
-  email  = "aws-cloud-pb-ct+sh@cds-snc.ca"
+  email = "aws-cloud-pb-ct+sh@cds-snc.ca"
 }
 
 module "audit" {
   source = "../../modules/existing_security_hub_member"
   providers = {
-    aws.admin = aws.log_archive
+    aws.admin  = aws.log_archive
     aws.member = aws.audit_log
   }
 
-  email  = "aws-cloud-pb-ct+sh@cds-snc.ca"
+  email = "aws-cloud-pb-ct+sh@cds-snc.ca"
 }
 
 module "aft_managment" {
   source = "../../modules/existing_security_hub_member"
   providers = {
-    aws.admin = aws.log_archive
+    aws.admin  = aws.log_archive
     aws.member = aws.aft_management
   }
 
-  email  = "aws-cloud-pb-ct+sh@cds-snc.ca"
+  email = "aws-cloud-pb-ct+sh@cds-snc.ca"
 }

--- a/terragrunt/org_account/main/securityhub.tf
+++ b/terragrunt/org_account/main/securityhub.tf
@@ -19,70 +19,32 @@ resource "aws_securityhub_standards_subscription" "cis_aws_foundations_benchmark
   depends_on = [aws_securityhub_organization_admin_account.admin_account]
 }
 
-
-
-# invites
-
-resource "aws_securityhub_account" "org" {}
-
-resource "aws_securityhub_member" "org" {
-  provider = aws.log_archive
-
-  account_id = var.org_account
+module "org" {
+  source = "../../modules/existing_security_hub_member"
+  providers = {
+    aws.admin = aws.log_archive
+    aws.member = aws
+  }
 
   email  = "aws-cloud-pb-ct+sh@cds-snc.ca"
-  invite = true
-
-  depends_on = [aws_securityhub_account.org]
-
 }
 
-resource "aws_securityhub_invite_accepter" "org" {
-  master_id  = aws_securityhub_member.org.master_id
-  depends_on = [aws_securityhub_member.org]
+module "audit" {
+  source = "../../modules/existing_security_hub_member"
+  providers = {
+    aws.admin = aws.log_archive
+    aws.member = aws.audit_log
+  }
+
+  email  = "aws-cloud-pb-ct+sh@cds-snc.ca"
 }
 
-# audit 
-resource "aws_securityhub_account" "audit" {
-  provider = aws.audit_log
+module "aft_managment" {
+  source = "../../modules/existing_security_hub_member"
+  providers = {
+    aws.admin = aws.log_archive
+    aws.member = aws.aft_management
+  }
+
+  email  = "aws-cloud-pb-ct+sh@cds-snc.ca"
 }
-
-resource "aws_securityhub_member" "audit" {
-  provider = aws.log_archive
-
-  account_id = "886481071419"
-  email      = "aws-cloud-pb-ct+sh@cds-snc.ca"
-  invite     = true
-
-  depends_on = [aws_securityhub_account.audit]
-}
-
-resource "aws_securityhub_invite_accepter" "audit" {
-  provider   = aws.audit_log
-  master_id  = aws_securityhub_member.audit.master_id
-  depends_on = [aws_securityhub_member.audit]
-}
-
-# aft_management
-
-
-resource "aws_securityhub_account" "aft_management" {
-  provider = aws.aft_management
-}
-
-resource "aws_securityhub_member" "aft_management" {
-  provider = aws.log_archive
-
-  account_id = "137554749751"
-  email      = "aws-cloud-pb-ct+sh@cds-snc.ca"
-  invite     = true
-
-  depends_on = [aws_securityhub_account.aft_management]
-}
-
-resource "aws_securityhub_invite_accepter" "aft_management" {
-  provider   = aws.aft_management
-  master_id  = aws_securityhub_member.aft_management.master_id
-  depends_on = [aws_securityhub_member.aft_management]
-}
-


### PR DESCRIPTION
# Summary | Résumé

- refactored out adding existing security hub members through a module
- ignored changes to the email due to a known bug (see comment)

This also adds my personal IAM User as a trusted account to assume the assume_plan and assume_apply roles, this is required for refactoring and will be removed when that work is done.


**Please Note:** The refactoring work was done locally, I'm not quite ready to try out the move commands.
