### PR TITLE
feat: publish findings in all regions

### DIFF
--- a/terragrunt/org_account/main/guardduty.tf
+++ b/terragrunt/org_account/main/guardduty.tf
@@ -223,3 +223,21 @@ resource "aws_guardduty_publishing_destination" "pub_dest" {
   destination_arn = module.publishing_bucket.s3_bucket_arn
   kms_key_arn     = aws_kms_key.cds_sentinel_guard_duty_key.arn
 }
+
+resource "aws_guardduty_publishing_destination" "pub_dest_us_east_1" {
+
+  provider = aws.log_archive_us_east_1
+
+  detector_id     = module.gd_log_archive_detector.us_east_1_detector_id
+  destination_arn = module.publishing_bucket.s3_bucket_arn
+  kms_key_arn     = aws_kms_key.cds_sentinel_guard_duty_key.arn
+}
+
+resource "aws_guardduty_publishing_destination" "pub_dest_us_west_2" {
+
+  provider = aws.log_archive_us_west_2
+
+  detector_id     = module.gd_log_archive_detector.us_east_1_detector_id
+  destination_arn = module.publishing_bucket.s3_bucket_arn
+  kms_key_arn     = aws_kms_key.cds_sentinel_guard_duty_key.arn
+}


### PR DESCRIPTION
# Summary | Résumé

Enable publishing guardduty findings in us_east_1 and us_west_2


