### PR TITLE
feat: enable guardduty sentinel forwarding

### DIFF
--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -26,6 +26,8 @@ jobs:
           module: main
           account: 659087519042
           assume_role_name: "assume_apply"
+          lz_customer_id: LZ_CUSTOMER_ID
+          lz_shared_key: LZ_SHARED_KEY
 
         - account_folder: org_account
           module: aft
@@ -63,5 +65,7 @@ jobs:
         env:
           TF_VAR_aft_slack_webhook: ${{ secrets[matrix.lz_webhook_key] }}
           TF_VAR_assume_role_name: ${{ matrix.assume_role_name }}
+          TF_VAR_lw_customer_id: ${{ secrets[matrix.lz_customer_id] }}
+          TF_VAR_lw_shared_key: ${{ secrets[matrix.lz_shared_key] }}
         run: |
           terragrunt apply --terragrunt-non-interactive -auto-approve

--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -31,6 +31,8 @@ jobs:
             account: 659087519042
             role: CDSLZTerraformReadOnlyRole
             assume_role_name: "assume_plan"
+            lz_customer_id: LZ_CUSTOMER_ID
+            lz_shared_key: LZ_SHARED_KEY
 
           - account_folder: log_archive
             module: main
@@ -68,6 +70,8 @@ jobs:
         env:
           TF_VAR_aft_slack_webhook: ${{ secrets[matrix.lz_webhook_key] }}
           TF_VAR_assume_role_name: ${{ matrix.assume_role_name }}
+          TF_VAR_lw_customer_id: ${{ secrets[matrix.lz_customer_id] }}
+          TF_VAR_lw_shared_key: ${{ secrets[matrix.lz_shared_key] }}
         uses: cds-snc/terraform-plan@v2
         with:
           comment-delete: true

--- a/terragrunt/org_account/main/input.tf
+++ b/terragrunt/org_account/main/input.tf
@@ -4,11 +4,11 @@ variable "assume_role_name" {
 }
 
 variable "lw_customer_id" {
-  type = string
+  type        = string
   description = "The log workspace customer id for the sentinel forwarder"
 }
 
 variable "lw_shared_key" {
-  type = string
+  type        = string
   description = "The log workspace shared key for the sentinel forwarder"
 }

--- a/terragrunt/org_account/main/input.tf
+++ b/terragrunt/org_account/main/input.tf
@@ -2,3 +2,13 @@ variable "assume_role_name" {
   type        = string
   description = "The name of the role to assume"
 }
+
+variable "lw_customer_id" {
+  type = string
+  description = "The log workspace customer id for the sentinel forwarder"
+}
+
+variable "lw_shared_key" {
+  type = string
+  description = "The log workspace shared key for the sentinel forwarder"
+}

--- a/terragrunt/org_account/main/sentinel_forwarders.tf
+++ b/terragrunt/org_account/main/sentinel_forwarders.tf
@@ -1,17 +1,17 @@
 module "guardduty_forwarder" {
-  source = "github.com/cds-snc/terraform-modules?ref=v2.0.5//sentinel_forwarder"
-  function_name = "senting-guard-duty-forwarder"
+  source            = "github.com/cds-snc/terraform-modules?ref=v2.0.5//sentinel_forwarder"
+  function_name     = "senting-guard-duty-forwarder"
   billing_tag_value = var.billing_code
 
   customer_id = var.lw_customer_id
-  shared_key = var.lw_shared_key
+  shared_key  = var.lw_shared_key
 
   s3_sources = [
     {
-      bucket_arn = module.publishing_bucket.s3_bucket_arn
-      bucket_id = module.publishing_bucket.s3_bucket_id
+      bucket_arn    = module.publishing_bucket.s3_bucket_arn
+      bucket_id     = module.publishing_bucket.s3_bucket_id
       filter_prefix = "AWSLogs/"
-      kms_key_arn = aws_kms_key.cds_sentinel_guard_duty_key.arn
+      kms_key_arn   = aws_kms_key.cds_sentinel_guard_duty_key.arn
     }
   ]
 }

--- a/terragrunt/org_account/main/sentinel_forwarders.tf
+++ b/terragrunt/org_account/main/sentinel_forwarders.tf
@@ -1,0 +1,17 @@
+module "guardduty_forwarder" {
+  source = "github.com/cds-snc/terraform-modules?ref=v2.0.5//sentinel_forwarder"
+  function_name = "senting-guard-duty-forwarder"
+  billing_tag_value = var.billing_code
+
+  customer_id = var.lw_customer_id
+  shared_key = var.lw_shared_key
+
+  s3_sources = [
+    {
+      bucket_arn = module.publishing_bucket.s3_bucket_arn
+      bucket_id = module.publishing_bucket.s3_bucket_id
+      filter_prefix = "AWSLogs/"
+      kms_key_arn = aws_kms_key.cds_sentinel_guard_duty_key.arn
+    }
+  ]
+}


### PR DESCRIPTION
# Summary | Résumé

This uses the terraform module that is already in use by the ALZ org
account


This closes: https://github.com/cds-snc/site-reliability-engineering/issues/470