### PR TITLE
fix: move module to log_archive account

### DIFF
--- a/terragrunt/org_account/main/sentinel_forwarders.tf
+++ b/terragrunt/org_account/main/sentinel_forwarders.tf
@@ -1,4 +1,8 @@
 module "guardduty_forwarder" {
+  providers = {
+    aws = aws.log_archive
+  }
+
   source            = "github.com/cds-snc/terraform-modules?ref=v2.0.5//sentinel_forwarder"
   function_name     = "senting-guard-duty-forwarder"
   billing_tag_value = var.billing_code


### PR DESCRIPTION
# Summary | Résumé

Move the guardduty_forwarder module over to the log_archive account in ca-central-1 instaed of running it in the org_account which didn't work anyways.

This fixes bug #67 


**CHANGES WERE APPLIED LOCALLY**