### PR TITLE
feat: adds cloudtrail forwarder

### DIFF
--- a/terragrunt/org_account/main/sentinel_forwarders.tf
+++ b/terragrunt/org_account/main/sentinel_forwarders.tf
@@ -1,10 +1,36 @@
+# Cloudtrail
+module "cloudtrail_forwarder" {
+  providers = {
+    aws = aws.log_archive
+  }
+
+  source            = "github.com/cds-snc/terraform-modules?ref=v3.0.2//sentinel_forwarder"
+  function_name     = "sentinel-cloud-trail-forwarder"
+  billing_tag_value = var.billing_code
+
+  customer_id = var.lw_customer_id
+  shared_key  = var.lw_shared_key
+
+  s3_sources = [
+    {
+      bucket_arn    = "arn:aws:s3:::aws-aft-logs-{data.aws_caller_identity.log_archive.account_id}-${var.region}"
+      bucket_id     = "aws-aft-logs-{data.aws_caller_identity.log_archive.account_id}-${var.region}"
+      filter_prefix = "AWSLogs/o-625no8z3dd/"
+      kms_key_arn   = "arn:aws:kms:${var.region}:${data.aws_caller_identity.log_archive.account_id}:key/72713e0c-b7f4-438a-9eca-41c36b775f30"
+    }
+  ]
+}
+
+
+
+# Guardduty
 module "guardduty_forwarder" {
   providers = {
     aws = aws.log_archive
   }
 
   source            = "github.com/cds-snc/terraform-modules?ref=v3.0.2//sentinel_forwarder"
-  function_name     = "senting-guard-duty-forwarder"
+  function_name     = "sentinal-guard-duty-forwarder"
   billing_tag_value = var.billing_code
 
   customer_id = var.lw_customer_id

--- a/terragrunt/org_account/main/sentinel_forwarders.tf
+++ b/terragrunt/org_account/main/sentinel_forwarders.tf
@@ -30,7 +30,7 @@ module "guardduty_forwarder" {
   }
 
   source            = "github.com/cds-snc/terraform-modules?ref=v3.0.2//sentinel_forwarder"
-  function_name     = "sentinal-guard-duty-forwarder"
+  function_name     = "sentinel-guard-duty-forwarder"
   billing_tag_value = var.billing_code
 
   customer_id = var.lw_customer_id


### PR DESCRIPTION
Closes https://github.com/cds-snc/site-reliability-engineering/issues/495 by adding a sentinel forwarder that attaches to the the cloud trail log bucket. TBD is if the KMS key that encrypts the logs needs to have the lambda principle added.