### PR TITLE
feat: send security hub events to sentinel

### DIFF
--- a/terragrunt/org_account/main/eventbridge.tf
+++ b/terragrunt/org_account/main/eventbridge.tf
@@ -1,0 +1,23 @@
+resource "aws_cloudwatch_event_rule" "cds_sentinel_securityhub_rule" {
+  provider    = aws.log_archive
+  name        = "cds-sentinel-securityhub-rule"
+  description = "Capture security hub events"
+
+  event_pattern = <<PATTERN
+{
+  "source": [
+    "aws.securityhub"
+  ],
+  "detail-type": [
+    "Security Hub Findings - Imported"
+  ],
+  "detail": {
+    "findings": {
+      "Severity": [
+        "CRITICAL", "HIGH", "MEDIUM", "LOW"
+      ]
+    }
+  }
+}
+PATTERN
+}

--- a/terragrunt/org_account/main/sentinel_forwarders.tf
+++ b/terragrunt/org_account/main/sentinel_forwarders.tf
@@ -57,7 +57,7 @@ module "securityhub_forwarder" {
 
   source            = "github.com/cds-snc/terraform-modules?ref=v3.0.2//sentinel_forwarder"
   function_name     = "sentinel-securityhub-forwarder"
-  billing_tag_value = var.billling_code
+  billing_tag_value = var.billing_code
 
   customer_id = var.lw_customer_id
   shared_key  = var.lw_shared_key

--- a/terragrunt/org_account/main/sentinel_forwarders.tf
+++ b/terragrunt/org_account/main/sentinel_forwarders.tf
@@ -45,3 +45,23 @@ module "guardduty_forwarder" {
     }
   ]
 }
+
+
+
+# Security Hub
+
+module "securityhub_forwarder" {
+  providers = {
+    aws = aws.log_archive
+  }
+
+  source            = "github.com/cds-snc/terraform-modules?ref=v3.0.2//sentinel_forwarder"
+  function_name     = "sentinel-securityhub-forwarder"
+  billing_tag_value = var.billling_code
+
+  customer_id = var.lw_customer_id
+  shared_key  = var.lw_shared_key
+
+  event_rule_name = [aws_cloudwatch_event_rule.cds_sentinel_securityhub_rule.name]
+
+}

--- a/terragrunt/org_account/main/sentinel_forwarders.tf
+++ b/terragrunt/org_account/main/sentinel_forwarders.tf
@@ -62,6 +62,6 @@ module "securityhub_forwarder" {
   customer_id = var.lw_customer_id
   shared_key  = var.lw_shared_key
 
-  event_rule_name = [aws_cloudwatch_event_rule.cds_sentinel_securityhub_rule.name]
+  event_rule_names = [aws_cloudwatch_event_rule.cds_sentinel_securityhub_rule.name]
 
 }


### PR DESCRIPTION
# Summary | Résumé

Since we can just send from the log_archive account there is no need to
forward the events to another eventbridge like we did in the existing
Landing Zone Instance.

Closes https://github.com/cds-snc/site-reliability-engineering/issues/491

