### PR TITLE
feat: upgrade AFT to 1.6.2

### DIFF
--- a/terragrunt/org_account/aft/main.tf
+++ b/terragrunt/org_account/aft/main.tf
@@ -1,5 +1,5 @@
 module "account_factory_for_terraform" {
-  source = "github.com/aws-ia/terraform-aws-control_tower_account_factory?ref=1.4.2"
+  source = "github.com/aws-ia/terraform-aws-control_tower_account_factory?ref=1.6.2"
 
   terraform_version = "1.1.7"
 


### PR DESCRIPTION
# Summary | Résumé
Changlog: 

https://github.com/aws-ia/terraform-aws-control_tower_account_factory/compare/1.4.2...1.6.2


Closes #77 as it's no longer needed