### PR TITLE
feat: adds migration scripts

### DIFF
--- a/bin/migrate/create_awsctexec_role.sh
+++ b/bin/migrate/create_awsctexec_role.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+POLICY_NAME="AWSControlTowerExection"
+
+read -r -d '' INPUT <<EOF
+
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {
+        "AWS": "arn:aws:iam::659087519042:root"
+      },
+    "Action": "sts:AssumeRole",
+    "Condition": {}
+  }]
+}
+
+EOF
+
+echo "Creating role $POLICY_NAME"
+aws iam create-role --role-name "$POLICY_NAME" \
+  --assume-role-policy-document "$(jq <<< "$INPUT")"
+
+echo "Attach AdministratorAccess policy to $POLICY_NAME"
+aws iam attach-role-policy --role-name "$POLICY_NAME" \
+  --policy-arn arn:aws:iam::aws:policy/AdministratorAccess 

--- a/bin/migrate/invoke_account.sh
+++ b/bin/migrate/invoke_account.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+ACCOUNT_ID=$1
+
+if [ -z "$ACCOUNT_ID" ]; then
+  echo "Usage: invoke_account.sh <account_id>"
+  exit 1
+fi
+
+
+
+read -r -d '' INPUT <<EOF
+{
+  "include" : [
+    {
+      "type": "accounts",
+      "target_value": ["$ACCOUNT_ID"]
+
+    }
+  ]
+}
+EOF
+
+TIMESTAMP=$(date +%s)
+
+
+aws stepfunctions start-execution \
+  --region "ca-central-1" \
+  --state-machine-arn "arn:aws:states:ca-central-1:137554749751:stateMachine:aft-invoke-customizations" \
+  --name  "$TIMESTAMP-invoke-customizations-all" \
+  --input "$(jq <<< "$INPUT")"

--- a/bin/migrate/remove_aft_created_resources.sh
+++ b/bin/migrate/remove_aft_created_resources.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+ACCOUNT_ID=$(aws sts get-caller-identity --query 'Account' --output text)
+
+echo "Removing resources in account $ACCOUNT_ID"
+echo "Type REMOVE to confirm"
+read -r RESPONSE
+
+if [ "$RESPONSE" == "REMOVE" ]; then
+  echo "Removing resources in account $ACCOUNT_ID"
+
+  echo "Removing Github OIDC Provider"
+  aws iam delete-open-id-connect-provider --open-id-connect-provider-arn "arn:aws:iam::$ACCOUNT_ID:oidc-provider/token.actions.githubusercontent.com"
+
+  echo "Removing secopsAssetInventorySecurityAuditRole"
+  aws iam detach-role-policy --policy-arn arn:aws:iam::aws:policy/SecurityAudit --role-name secopsAssetInventorySecurityAuditRole
+  aws iam delete-role --role-name secopsAssetInventorySecurityAuditRole
+
+  echo "Removing ConfigTerraformAdminExecutionRole"
+  aws iam detach-role-policy --policy-arn arn:aws:iam::aws:policy/AdministratorAccess --role-name ConfigTerraformAdminExecutionRole
+  aws iam delete-role --role-name ConfigTerraformAdminExecutionRole
+
+  echo "Removing CbsSatelliteReplicateToLogArchive"
+  aws iam detach-role-policy --policy-arn arn:aws:iam::806545929748:policy/CbsSatelliteReplicateToLogArchive --role-name CbsSatelliteReplicateToLogArchive
+  aws iam delete-role --role-name CbsSatelliteReplicateToLogArchive
+  aws iam delete-policy --policy-arn arn:aws:iam::806545929748:policy/CbsSatelliteReplicateToLogArchive
+
+else
+  echo "Aborting"
+fi


### PR DESCRIPTION
# Summary | Résumé

Adds the following scripts that are used during account migration.

- bin/migrate/create_awsctexec_role.sh
  Creates the `AWSControlTowerExecution` role that's required by control
tower for creating resources in the account

- bin/migrate/remove_aft_created_resources.sh
  Deletes resources that are created by AFT, this should fail for some
lines of these script as some resources are only used by some environments

- bin/migrate/invoke_account.sh
  Invokes the AFT codepipeline for a specific account


