### PR TITLE
fix: apply right module

### DIFF
--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -31,7 +31,7 @@ jobs:
           spend_notifier_hook: SPEND_NOTIFIER_HOOK
 
         - account_folder: org_account
-          module: main
+          module: spend_notifier
           account: 659087519042
           assume_role_name: "assume_apply"
           spend_notifier_hook: SPEND_NOTIFIER_HOOK


### PR DESCRIPTION
# Summary | Résumé

The previous PR ran a tf plan in the right module but tried to apply the main module again. 

It failed due to a statelock this one should work.
