### PR TITLE
fix: service identifier for spend notifier

### DIFF
--- a/terragrunt/org_account/spend_notifier/iam.tf
+++ b/terragrunt/org_account/spend_notifier/iam.tf
@@ -5,7 +5,7 @@ data "aws_iam_policy_document" "spend_notifier_role" {
     principals {
       type = "Service"
       identifiers = [
-      "sts:AssumeRole"]
+      "lambda.amazonaws.com"]
     }
   }
 }


### PR DESCRIPTION
# Summary | Résumé

- the service identifier was incorrect had the action instead of the
  service

