### PR TITLE
fix: issues with spend_notifier lambda

### DIFF
--- a/terragrunt/org_account/spend_notifier/lambdas/spend_notifier/spend_notifier.js
+++ b/terragrunt/org_account/spend_notifier/lambdas/spend_notifier/spend_notifier.js
@@ -91,7 +91,7 @@ async function getAccounts() {
   for (let i = 0; i < accounts.length; i++) {
     let account = accounts[i];
     let tags = await organizations.listTagsForResource({ ResourceId: account["Id"] }).promise()
-    results[account["Id"]] = { Name: account["Name"], BU: tags.Tags.find(tag => tag["Key"] == "Business Unit").Value }
+    results[account["Id"]] = { Name: account["Name"], BU: tags.Tags.find(tag => tag["Key"] == "business_unit").Value }
   }
   return results
 }


### PR DESCRIPTION
# Summary | Résumé

- Increase timeout to 30 seconds
- Allow Eventbridge rules to invoke lambda
- Remove 0 concurrent runs
- Change key of Business Unit tag to match new values


This will still fail in the SRE bot message but I think the fix is there not here. 