### PR TITLE
fix: add log group and lambda insights

### DIFF
--- a/terragrunt/org_account/spend_notifier/iam.tf
+++ b/terragrunt/org_account/spend_notifier/iam.tf
@@ -65,3 +65,12 @@ resource "aws_iam_role_policy_attachment" "org_read_only" {
   role       = aws_iam_role.spend_notifier.name
   policy_arn = data.aws_iam_policy.org_read_only.arn
 }
+
+data "aws_iam_policy" "lambda_insights" {
+  name  = "CloudWatchLambdaInsightsExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_insights" {
+  role       = aws_iam_role.spend_notifier.name
+  policy_arn = data.aws_iam_policy.lambda_insights.arn
+}

--- a/terragrunt/org_account/spend_notifier/iam.tf
+++ b/terragrunt/org_account/spend_notifier/iam.tf
@@ -67,7 +67,7 @@ resource "aws_iam_role_policy_attachment" "org_read_only" {
 }
 
 data "aws_iam_policy" "lambda_insights" {
-  name  = "CloudWatchLambdaInsightsExecutionRolePolicy"
+  name = "CloudWatchLambdaInsightsExecutionRolePolicy"
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_insights" {

--- a/terragrunt/org_account/spend_notifier/lambda.tf
+++ b/terragrunt/org_account/spend_notifier/lambda.tf
@@ -43,3 +43,9 @@ resource "aws_lambda_permission" "allow_weekly_budget" {
 }
 
 
+resource "aws_cloudwatch_log_group" "this" {
+  #checkov:skip=CKV_AWS_158:We trust the AWS provided keys
+  name              = "/aws/lambda/${aws_lambda_function.spend_notifier.name}"
+  retention_in_days = "14"
+  tags              = local.common_tags
+}

--- a/terragrunt/org_account/spend_notifier/lambda.tf
+++ b/terragrunt/org_account/spend_notifier/lambda.tf
@@ -45,7 +45,7 @@ resource "aws_lambda_permission" "allow_weekly_budget" {
 
 resource "aws_cloudwatch_log_group" "this" {
   #checkov:skip=CKV_AWS_158:We trust the AWS provided keys
-  name              = "/aws/lambda/${aws_lambda_function.spend_notifier.name}"
+  name              = "/aws/lambda/${aws_lambda_function.spend_notifier.function_name}"
   retention_in_days = "14"
   tags              = local.common_tags
 }


### PR DESCRIPTION
# Summary | Résumé

Attach the policy for lambda insights.
Create a log group so we can figure out why it failed to execute from
eventbridge.


