### PR TITLE
feat: SRE OIDC role to manage permissions

### DIFF
--- a/terragrunt/org_account/main/locals.tf
+++ b/terragrunt/org_account/main/locals.tf
@@ -1,7 +1,10 @@
-
 locals {
-  plan_name       = "CDSLZTerraformReadOnlyRole"
-  admin_name      = "CDSLZTerraformAdministratorRole"
-  admin_plan_role = "CDSLZTerraformAdminPlanRole"
-  admin_account   = "274536870005"
+  plan_name                  = "CDSLZTerraformReadOnlyRole"
+  admin_name                 = "CDSLZTerraformAdministratorRole"
+  admin_plan_role            = "CDSLZTerraformAdminPlanRole"
+  admin_account              = "274536870005"
+  sre_sso_manage_permissions = "SSOManagePermissionsRole"
+
+  sso_identity_store_id = "d-9d67173bdd"
+  sso_instance_id       = "ssoins-8824c710b5ddb452"
 }

--- a/terragrunt/org_account/main/oidc_role.tf
+++ b/terragrunt/org_account/main/oidc_role.tf
@@ -17,7 +17,7 @@ module "gh_oidc_roles" {
       claim     = "*"
     },
     {
-      name      = local.sre_sso_manage_perms
+      name      = local.sre_sso_manage_permissions
       repo_name = "site-reliability-engineering"
       claim     = "*"
     }


### PR DESCRIPTION
# Summary
Add an OIDC role that will be used by the `site-reliability-engineering` repo to manage SSO permission assignments.

This will be used by the [on-call rotate script workflow](https://github.com/cds-snc/site-reliability-engineering/blob/main/.github/workflows/on_call_rotate_notify.yml).

# Related
- cds-snc/site-reliability-engineering#594