### PR TITLE
fix: set default region in the create ops script

### DIFF
--- a/bin/create_ops_users.sh
+++ b/bin/create_ops_users.sh
@@ -8,6 +8,9 @@ fi
 
 ACCOUNT_ID=$(aws sts get-caller-identity --query 'Account' --output text)
 
+# shellcheck disable=SC2034
+AWS_DEFAULT_REGION="ca-central-1"
+
 aws iam create-group --group-name admins
 aws iam attach-group-policy --policy-arn arn:aws:iam::aws:policy/AdministratorAccess --group-name admins
 


### PR DESCRIPTION
# Summary
Update the create Ops user script to set a default region.  Not having
this set caused an error when I was using the script with exported
AWS credentials rather than a configured AWS cli profile.