### PR TITLE
fix: add `region` arg to AWS cli command

### DIFF
--- a/bin/create_ops_users.sh
+++ b/bin/create_ops_users.sh
@@ -8,20 +8,17 @@ fi
 
 ACCOUNT_ID=$(aws sts get-caller-identity --query 'Account' --output text)
 
-# shellcheck disable=SC2034
-AWS_DEFAULT_REGION="ca-central-1"
-
 aws iam create-group --group-name admins
 aws iam attach-group-policy --policy-arn arn:aws:iam::aws:policy/AdministratorAccess --group-name admins
 
 aws iam create-user --user-name ops1
 aws iam add-user-to-group --user-name ops1 --group-name admins
-OPS1PWORD=$(aws secretsmanager get-random-password | jq -r '.RandomPassword')
+OPS1PWORD=$(aws secretsmanager get-random-password --region ca-central-1 | jq -r '.RandomPassword')
 aws iam create-login-profile --user-name ops1 --password "$OPS1PWORD"
 
 aws iam create-user --user-name ops2
 aws iam add-user-to-group --user-name ops2 --group-name admins
-OPS2PWORD=$(aws secretsmanager get-random-password | jq -r '.RandomPassword')
+OPS2PWORD=$(aws secretsmanager get-random-password --region ca-central-1 | jq -r '.RandomPassword')
 aws iam create-login-profile --user-name ops2 --password "$OPS2PWORD"
 
 lpass add --notes "Shared-SRE - AWS Cloud credentials/Control Tower/$ACCOUNT_ID" --non-interactive --sync=now <<EOF


### PR DESCRIPTION
# Summary
The variable I set previously was not passing correctly to the subshell created by `$()`.

# Region
- cds-snc/site-reliability-engineering#624