### PR TITLE
feat: add role for SRE bot

### DIFF
--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -21,47 +21,51 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - account_folder: org_account
+            module: main
+            account: 659087519042
+            assume_role_name: "assume_apply"
+            la_customer_id: LA_CUSTOMER_ID
+            la_shared_key: LA_SHARED_KEY
 
-        - account_folder: org_account
-          module: main
-          account: 659087519042
-          assume_role_name: "assume_apply"
-          la_customer_id: LA_CUSTOMER_ID
-          la_shared_key: LA_SHARED_KEY
+          - account_folder: org_account
+            module: spend_notifier
+            account: 659087519042
+            assume_role_name: "assume_apply"
+            spend_notifier_hook: SPEND_NOTIFIER_HOOK
+            weekly_spend_notifier_hook: WEEKLY_SPEND_NOTIFIER_HOOK
 
-        - account_folder: org_account
-          module: spend_notifier
-          account: 659087519042
-          assume_role_name: "assume_apply"
-          spend_notifier_hook: SPEND_NOTIFIER_HOOK
-          weekly_spend_notifier_hook: WEEKLY_SPEND_NOTIFIER_HOOK
+          - account_folder: org_account
+            module: sre_bot
+            account: 659087519042
+            assume_role_name: "assume_apply"
 
-        - account_folder: org_account
-          module: aft
-          account: 659087519042
+          - account_folder: org_account
+            module: aft
+            account: 659087519042
 
-        - account_folder: log_archive
-          module: main
-          account: 274536870005
+          - account_folder: log_archive
+            module: main
+            account: 274536870005
 
-        - account_folder: log_archive
-          module: legacy_archives
-          account: 274536870005
+          - account_folder: log_archive
+            module: legacy_archives
+            account: 274536870005
 
-        - account_folder: audit
-          module: main
-          account: 886481071419
+          - account_folder: audit
+            module: main
+            account: 886481071419
 
-        - account_folder: aft
-          module: main
-          account: 137554749751
-          lz_webhook_key: LZ_CHANNEL_WEBHOOK
+          - account_folder: aft
+            module: main
+            account: 137554749751
+            lz_webhook_key: LZ_CHANNEL_WEBHOOK
 
-        - account_folder: aft
-          module: notifications
-          account: 137554749751
-          role: CDSLZTerraformReadOnlyRole
-          aft_notifications_hook: AFT_NOTIFICATIONS_HOOK
+          - account_folder: aft
+            module: notifications
+            account: 137554749751
+            role: CDSLZTerraformReadOnlyRole
+            aft_notifications_hook: AFT_NOTIFICATIONS_HOOK
 
     steps:
       - name: Checkout

--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -20,7 +20,6 @@ permissions:
   statuses: write
 
 jobs:
-
   terraform-plan-account:
     strategy:
       fail-fast: false
@@ -40,6 +39,11 @@ jobs:
             role: CDSLZTerraformReadOnlyRole
             spend_notifier_hook: SPEND_NOTIFIER_HOOK
             weekly_spend_notifier_hook: WEEKLY_SPEND_NOTIFIER_HOOK
+
+          - account_folder: org_account
+            module: sre_bot
+            account: 659087519042
+            role: CDSLZTerraformReadOnlyRole
 
           - account_folder: log_archive
             module: main

--- a/terragrunt/log_archive/legacy_archives/main.tf
+++ b/terragrunt/log_archive/legacy_archives/main.tf
@@ -3,6 +3,8 @@ module "aws-landing-zone-logs_bucket" {
 
   bucket_name       = "legacy-aws-landing-zone-logs"
   billing_tag_value = var.billing_code
+
+  kms_key_arn = "arn:aws:kms:ca-central-1:${var.account_id}:alias/aws/s3"
 }
 
 module "aws-landing-zone-s3-access-logs_bucket" {

--- a/terragrunt/log_archive/legacy_archives/main.tf
+++ b/terragrunt/log_archive/legacy_archives/main.tf
@@ -1,5 +1,5 @@
 module "aws-landing-zone-logs_bucket" {
-  source = "github.com/cds-snc/terraform-modules?ref=v3.0.19//S3"
+  source = "github.com/cds-snc/terraform-modules?ref=v3.0.20//S3"
 
   bucket_name       = "legacy-aws-landing-zone-logs"
   billing_tag_value = var.billing_code
@@ -8,7 +8,7 @@ module "aws-landing-zone-logs_bucket" {
 }
 
 module "aws-landing-zone-s3-access-logs_bucket" {
-  source = "github.com/cds-snc/terraform-modules?ref=v3.0.19//S3"
+  source = "github.com/cds-snc/terraform-modules?ref=v3.0.20//S3"
 
   bucket_name       = "legacy-aws-landing-zone-s3-access-logs"
   billing_tag_value = var.billing_code

--- a/terragrunt/org_account/sre_bot/iam.tf
+++ b/terragrunt/org_account/sre_bot/iam.tf
@@ -6,7 +6,7 @@ data "aws_iam_policy_document" "sre_bot_role" {
       type = "AWS"
       identifiers = [
         "arn:aws:iam::283582579564:role/sre-bot-ecs-role",
-        "arn:aws:iam::${var.org_account}:user/MaxNeuvians"
+        "arn:aws:iam::${var.org_account}:role/AWSReservedSSO_AWSAdministratorAccess_*"
       ]
     }
   }

--- a/terragrunt/org_account/sre_bot/iam.tf
+++ b/terragrunt/org_account/sre_bot/iam.tf
@@ -1,0 +1,62 @@
+data "aws_iam_policy_document" "sre_bot_role" {
+  statement {
+    sid     = "AssumeRole"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::283582579564:role/sre-bot-ecs-role",
+        "arn:aws:iam::${var.org_account}:user/MaxNeuvians"
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role" "sre_bot" {
+  name               = "sre_bot_role"
+  assume_role_policy = data.aws_iam_policy_document.sre_bot_role.json
+
+  tags = local.common_tags
+}
+
+data "aws_iam_policy_document" "sre_bot_policy" {
+  version = "2012-10-17"
+
+  statement {
+    sid       = "ReadOrgAccounts"
+    effect    = "Allow"
+    actions   = ["organizations:ListAccounts"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "ReadTrustedAdvisor"
+    effect = "Allow"
+    actions = [
+      "trustedadvisor:DescribeAccount",
+      "trustedadvisor:DescribeChecks",
+      "trustedadvisor:DescribeCheckSummaries",
+      "trustedadvisor:DescribeAccountAccess",
+      "trustedadvisor:DescribeOrganization",
+      "trustedadvisor:DescribeReports",
+      "trustedadvisor:DescribeServiceMetadata",
+      "trustedadvisor:DescribeOrganizationAccounts",
+      "trustedadvisor:ListAccountsForParent",
+      "trustedadvisor:ListRoots",
+      "trustedadvisor:ListOrganizationalUnitsForParent"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "sre_bot_policy" {
+  name   = "sre_bot_policy"
+  policy = data.aws_iam_policy_document.sre_bot_policy.json
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "sre_bot" {
+  role       = aws_iam_role.sre_bot.name
+  policy_arn = aws_iam_policy.sre_bot_policy.arn
+}

--- a/terragrunt/org_account/sre_bot/locals.tf
+++ b/terragrunt/org_account/sre_bot/locals.tf
@@ -1,0 +1,6 @@
+locals {
+  common_tags = {
+    CostCentre = var.billing_code
+    Terraform  = "true"
+  }
+}

--- a/terragrunt/org_account/sre_bot/terragrunt.hcl
+++ b/terragrunt/org_account/sre_bot/terragrunt.hcl
@@ -1,0 +1,3 @@
+include {
+  path = find_in_parent_folders()
+}


### PR DESCRIPTION
This PR adds a role and policy for the SRE Bot in it's account to access read resources inside the org account for trusted advisor and the org list.