### PR TITLE
fix: add admin_sso_role_arn as a secret

### DIFF
--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -92,6 +92,6 @@ jobs:
           TF_VAR_daily_spend_notifier_hook: ${{ secrets[matrix.spend_notifier_hook] }}
           TF_VAR_weekly_spend_notifier_hook: ${{ secrets[matrix.weekly_spend_notifier_hook]}}
           TF_VAR_aft_notifications_hook: ${{ secrets[matrix.aft_notifications_hook]}}
-          TV_VAR_admin_sso_role_arn: ${{ secrets[matrix.admin_sso_role_arn] }}
+          TF_VAR_admin_sso_role_arn: ${{ secrets[matrix.admin_sso_role_arn] }}
         run: |
           terragrunt apply --terragrunt-non-interactive -auto-approve

--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -39,6 +39,7 @@ jobs:
             module: sre_bot
             account: 659087519042
             assume_role_name: "assume_apply"
+            admin_sso_role_arn: ADMIN_SSO_ROLE_ARN
 
           - account_folder: org_account
             module: aft
@@ -91,5 +92,6 @@ jobs:
           TF_VAR_daily_spend_notifier_hook: ${{ secrets[matrix.spend_notifier_hook] }}
           TF_VAR_weekly_spend_notifier_hook: ${{ secrets[matrix.weekly_spend_notifier_hook]}}
           TF_VAR_aft_notifications_hook: ${{ secrets[matrix.aft_notifications_hook]}}
+          TV_VAR_admin_sso_role_arn: ${{ secrets[matrix.admin_sso_role_arn] }}
         run: |
           terragrunt apply --terragrunt-non-interactive -auto-approve

--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -100,7 +100,7 @@ jobs:
           TF_VAR_daily_spend_notifier_hook: ${{ secrets[matrix.spend_notifier_hook] }}
           TF_VAR_weekly_spend_notifier_hook: ${{ secrets[matrix.weekly_spend_notifier_hook]}}
           TF_VAR_aft_notifications_hook: ${{ secrets[matrix.aft_notifications_hook]}}
-          TV_VAR_admin_sso_role_arn: ${{ secrets[matrix.admin_sso_role_arn] }}
+          TF_VAR_admin_sso_role_arn: ${{ secrets[matrix.admin_sso_role_arn] }}
         uses: cds-snc/terraform-plan@v2
         with:
           comment-delete: true

--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -44,6 +44,7 @@ jobs:
             module: sre_bot
             account: 659087519042
             role: CDSLZTerraformReadOnlyRole
+            admin_sso_role_arn: ADMIN_SSO_ROLE_ARN
 
           - account_folder: log_archive
             module: main
@@ -99,6 +100,7 @@ jobs:
           TF_VAR_daily_spend_notifier_hook: ${{ secrets[matrix.spend_notifier_hook] }}
           TF_VAR_weekly_spend_notifier_hook: ${{ secrets[matrix.weekly_spend_notifier_hook]}}
           TF_VAR_aft_notifications_hook: ${{ secrets[matrix.aft_notifications_hook]}}
+          TV_VAR_admin_sso_role_arn: ${{ secrets[matrix.admin_sso_role_arn] }}
         uses: cds-snc/terraform-plan@v2
         with:
           comment-delete: true

--- a/terragrunt/org_account/sre_bot/iam.tf
+++ b/terragrunt/org_account/sre_bot/iam.tf
@@ -6,7 +6,7 @@ data "aws_iam_policy_document" "sre_bot_role" {
       type = "AWS"
       identifiers = [
         "arn:aws:iam::283582579564:role/sre-bot-ecs-role",
-        "arn:aws:iam::${var.org_account}:role/AWSReservedSSO_AWSAdministratorAccess_*"
+        var.admin_sso_role_arn
       ]
     }
   }

--- a/terragrunt/org_account/sre_bot/iam.tf
+++ b/terragrunt/org_account/sre_bot/iam.tf
@@ -14,7 +14,7 @@ data "aws_iam_policy_document" "sre_bot_role" {
 
 resource "aws_iam_role" "sre_bot" {
   name               = "sre_bot_role"
-  assume_role_policy = data.aws_iam_policy_document.sre_bot_role.json
+  assume_role_policy = sensitive(data.aws_iam_policy_document.sre_bot_role.json)
 
   tags = local.common_tags
 }

--- a/terragrunt/org_account/sre_bot/inputs.tf
+++ b/terragrunt/org_account/sre_bot/inputs.tf
@@ -1,0 +1,5 @@
+variable "admin_sso_role_arn" {
+  type        = string
+  description = "(Required) The ARN for the admin SSO role"
+  sensitive   = true
+}


### PR DESCRIPTION
This PR adds the Admin SSO role ARN as a secret to the principles that can assume roles for SRE-Bot