### PR TITLE
feat: add roles for log archive

### DIFF
--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -53,6 +53,12 @@ jobs:
             module: legacy_archives
             account: 274536870005
 
+          - account_folder: log_archive
+            module: sre_bot
+            account: 274536870005
+            assume_role_name: "assume_apply"
+            admin_sso_role_arn: ADMIN_SSO_ROLE_ARN
+
           - account_folder: audit
             module: main
             account: 886481071419

--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -56,6 +56,12 @@ jobs:
             account: 274536870005
             role: CDSLZTerraformReadOnlyRole
 
+          - account_folder: log_archive
+            module: sre_bot
+            account: 274536870005
+            role: CDSLZTerraformReadOnlyRole
+            admin_sso_role_arn: ADMIN_SSO_ROLE_ARN
+
           - account_folder: audit
             module: main
             account: 886481071419

--- a/terragrunt/log_archive/sre_bot/iam.tf
+++ b/terragrunt/log_archive/sre_bot/iam.tf
@@ -23,17 +23,23 @@ data "aws_iam_policy_document" "sre_bot_policy" {
   version = "2012-10-17"
 
   statement {
-    sid       = "ReadOrgAccounts"
-    effect    = "Allow"
-    actions   = ["organizations:ListAccounts"]
+    sid    = "ReadGuardDuty"
+    effect = "Allow"
+    actions = [
+      "guardduty:Describe*",
+      "guardduty:Get*",
+      "guardduty:List*"
+    ]
     resources = ["*"]
   }
 
   statement {
-    sid    = "ReadCostExplorer"
+    sid    = "ReadSecurityHub"
     effect = "Allow"
     actions = [
-      "ce:GetCostAndUsage"
+      "securityhub:Get*",
+      "securityhub:List*",
+      "securityhub:Describe*"
     ]
     resources = ["*"]
   }

--- a/terragrunt/log_archive/sre_bot/inputs.tf
+++ b/terragrunt/log_archive/sre_bot/inputs.tf
@@ -1,0 +1,5 @@
+variable "admin_sso_role_arn" {
+  type        = string
+  description = "(Required) The ARN for the admin SSO role"
+  sensitive   = true
+}

--- a/terragrunt/log_archive/sre_bot/locals.tf
+++ b/terragrunt/log_archive/sre_bot/locals.tf
@@ -1,0 +1,6 @@
+locals {
+  common_tags = {
+    CostCentre = var.billing_code
+    Terraform  = "true"
+  }
+}

--- a/terragrunt/log_archive/sre_bot/terragrunt.hcl
+++ b/terragrunt/log_archive/sre_bot/terragrunt.hcl
@@ -1,0 +1,3 @@
+include {
+  path = find_in_parent_folders()
+}


### PR DESCRIPTION
Removes the Trusted Advisor from the org IAM rule. Adds an IAM roles to the logging account for SecurityHub and GuardDuty.