### PR TITLE
feat: add audit account role for SRE bot

### DIFF
--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -63,6 +63,12 @@ jobs:
             module: main
             account: 886481071419
 
+          - account_folder: audit
+            module: sre_bot
+            account: 886481071419
+            assume_role_name: "assume_apply"
+            admin_sso_role_arn: ADMIN_SSO_ROLE_ARN
+
           - account_folder: aft
             module: main
             account: 137554749751

--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -67,6 +67,12 @@ jobs:
             account: 886481071419
             role: CDSLZTerraformReadOnlyRole
 
+          - account_folder: main
+            module: sre_bot
+            account: 886481071419
+            role: CDSLZTerraformReadOnlyRole
+            admin_sso_role_arn: ADMIN_SSO_ROLE_ARN
+
           - account_folder: aft
             module: main
             account: 137554749751

--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -67,7 +67,7 @@ jobs:
             account: 886481071419
             role: CDSLZTerraformReadOnlyRole
 
-          - account_folder: main
+          - account_folder: audit
             module: sre_bot
             account: 886481071419
             role: CDSLZTerraformReadOnlyRole

--- a/terragrunt/audit/sre_bot/iam.tf
+++ b/terragrunt/audit/sre_bot/iam.tf
@@ -23,20 +23,12 @@ data "aws_iam_policy_document" "sre_bot_policy" {
   version = "2012-10-17"
 
   statement {
-    sid    = "ReadGuardDuty"
+    sid    = "ReadConfig"
     effect = "Allow"
     actions = [
-      "guardduty:GetFindingsStatistics",
-      "guardduty:ListDetectors",
-    ]
-    resources = ["*"]
-  }
-
-  statement {
-    sid    = "ReadSecurityHub"
-    effect = "Allow"
-    actions = [
-      "securityhub:GetFindings",
+      "config:Describe*",
+      "config:Get*",
+      "config:List*",
     ]
     resources = ["*"]
   }

--- a/terragrunt/audit/sre_bot/inputs.tf
+++ b/terragrunt/audit/sre_bot/inputs.tf
@@ -1,0 +1,5 @@
+variable "admin_sso_role_arn" {
+  type        = string
+  description = "(Required) The ARN for the admin SSO role"
+  sensitive   = true
+}

--- a/terragrunt/audit/sre_bot/locals.tf
+++ b/terragrunt/audit/sre_bot/locals.tf
@@ -1,0 +1,6 @@
+locals {
+  common_tags = {
+    CostCentre = var.billing_code
+    Terraform  = "true"
+  }
+}

--- a/terragrunt/audit/sre_bot/terragrunt.hcl
+++ b/terragrunt/audit/sre_bot/terragrunt.hcl
@@ -1,0 +1,3 @@
+include {
+  path = find_in_parent_folders()
+}


### PR DESCRIPTION
This PR adds a role for the audit account that let the SRE bot look up AWS Config data. It also scopes down the SRE bot role to the Log account to the actual resources the SRE bot needs.