### PR TITLE
feat: additional SCPs

### DIFF
--- a/terragrunt/org_account/main/scp.tf
+++ b/terragrunt/org_account/main/scp.tf
@@ -42,6 +42,30 @@ data "aws_iam_policy_document" "cds_snc_universal_guardrails" {
   }
 
   statement {
+    sid    = "DoNotAllowIAMUsersOtherThanOps"
+    effect = "Deny"
+    actions = [
+      "iam:CreateUser"
+    ]
+    not_resources = [
+      "arn:aws:iam::*:user/ops1",
+      "arn:aws:iam::*:user/ops2"
+    ]
+  }
+
+  statement {
+    sid    = "DoNotAllowOpsUsersToBeDeleted"
+    effect = "Deny"
+    actions = [
+      "iam:DeleteUser"
+    ]
+    resources = [
+      "arn:aws:iam::*:user/ops1",
+      "arn:aws:iam::*:user/ops2"
+    ]
+  }
+
+  statement {
     sid    = "DoNotAllowIAMKeysOnOpsUsers"
     effect = "Deny"
     actions = [
@@ -50,6 +74,26 @@ data "aws_iam_policy_document" "cds_snc_universal_guardrails" {
     resources = [
       "arn:aws:iam::*:user/ops1",
       "arn:aws:iam::*:user/ops2"
+    ]
+  }
+
+  statement {
+    sid    = "DoNotAllowLeaveOrg"
+    effect = "Deny"
+    actions = [
+      "organizations:LeaveOrganization"
+    ]
+    resources = [
+      "*"
+    ]
+  }
+
+  statement {
+    sid    = "ProtectSecuritySettings"
+    effect = "Deny"
+    actions = [
+      "access-analyzer:DeleteAnalyzer",
+      "ec2:DisableEbsEncryptionByDefault",
     ]
   }
 }


### PR DESCRIPTION
Closes https://github.com/cds-snc/cds-aws-lz/issues/38. This PR adds additional SCPs based on the recommendations from here https://summitroute.com/blog/2020/03/25/aws_scp_best_practices/ and some CDS config items.

They include:

- Blocking all IAM user creation other than `ops1` and `ops2`.
- Blocking the deletion of `ops1` and `osp2` users
- Blocking an account from leaving the org and thus dropping SCPs
- Blocking the deletion of access analyzer
- Turning of EBS Encryption by default