### PR TITLE
save click ops to terraform for Sentinel OIDC

### DIFF
--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -48,6 +48,11 @@ jobs:
             module: aft
             account: 659087519042
             role: cds-aws-lz-apply
+          
+          - account_folder: org_account
+            module: sentinel_oidc
+            account: 659087519042
+            role: cds-aws-lz-apply
 
           - account_folder: log_archive
             module: main

--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -45,6 +45,12 @@ jobs:
             account: 659087519042
             role: cds-aws-lz-plan
             admin_sso_role_arn: ADMIN_SSO_ROLE_ARN
+          
+          - account_folder: org_account
+            module: sentinel_oidc
+            account: 659087519042
+            role: cds-aws-lz-plan
+            admin_sso_role_arn: ADMIN_SSO_ROLE_ARN
 
           - account_folder: log_archive
             module: main

--- a/terragrunt/org_account/.terraform.lock.hcl
+++ b/terragrunt/org_account/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.45.0"
+  constraints = ">= 4.40.0, < 5.0.0"
+  hashes = [
+    "h1:J/XjRsEJIpxi+mczXQfnH3nvfACv3LRDtrthQJCIibY=",
+    "zh:22da03786f25658a000d1bcc28c780816a97e7e8a1f59fff6eee7d452830e95e",
+    "zh:2543be56eee0491eb0c79ca1c901dcbf71da26625961fe719f088263fef062f4",
+    "zh:31a1da1e3beedfd88c3c152ab505bdcf330427f26b75835885526f7bb75c4857",
+    "zh:4409afe50f225659d5f378fe9303a45052953a1219f7f1acc82b69d07528b7ba",
+    "zh:4dadec3b783f10d2f8eef3dab5e817baae9c932a7967d45fe3d77fcbcbdaa438",
+    "zh:55be80d6e24828dcb0db7a0226fb275415c1c0ad63dd2f33b76f3ac0cd64e6a6",
+    "zh:560bba29efb7dbe0bfcc937369d88817aa31a8d18aa25395b1afe2576cb04495",
+    "zh:6caacc202e83438ff63d5d96733e283f44e349668d96c6b1c5c7df463ebf85cc",
+    "zh:6cabab83a61d5b4ac801c5a5d57556a0e76ec8dc879d28cf777509db5f6a657e",
+    "zh:96c4528bf9c16edb8841b68479ec51c499ed7fa680462fa28caeab3fc168bb43",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:cdc0b47ff840d708fbf75abfe86d23dc7f1dffdd233a771822a17b5c637f4769",
+    "zh:d9a9583e82776d1ebb6cf6c3d47acc2b302f8778f470ceffe7579dc794eb1feb",
+    "zh:e9367ca9f6f6418a23cdf8d01f29dd0c4f614e78499f52a767a422e4c334b915",
+    "zh:f6d355a2fb3bcebb597f68bbca4fa2aaa364efd29240236c582375e219d77656",
+  ]
+}

--- a/terragrunt/org_account/sentinel_oidc/.terraform.lock.hcl
+++ b/terragrunt/org_account/sentinel_oidc/.terraform.lock.hcl
@@ -1,0 +1,44 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.45.0"
+  constraints = ">= 4.40.0, < 5.0.0"
+  hashes = [
+    "h1:J/XjRsEJIpxi+mczXQfnH3nvfACv3LRDtrthQJCIibY=",
+    "zh:22da03786f25658a000d1bcc28c780816a97e7e8a1f59fff6eee7d452830e95e",
+    "zh:2543be56eee0491eb0c79ca1c901dcbf71da26625961fe719f088263fef062f4",
+    "zh:31a1da1e3beedfd88c3c152ab505bdcf330427f26b75835885526f7bb75c4857",
+    "zh:4409afe50f225659d5f378fe9303a45052953a1219f7f1acc82b69d07528b7ba",
+    "zh:4dadec3b783f10d2f8eef3dab5e817baae9c932a7967d45fe3d77fcbcbdaa438",
+    "zh:55be80d6e24828dcb0db7a0226fb275415c1c0ad63dd2f33b76f3ac0cd64e6a6",
+    "zh:560bba29efb7dbe0bfcc937369d88817aa31a8d18aa25395b1afe2576cb04495",
+    "zh:6caacc202e83438ff63d5d96733e283f44e349668d96c6b1c5c7df463ebf85cc",
+    "zh:6cabab83a61d5b4ac801c5a5d57556a0e76ec8dc879d28cf777509db5f6a657e",
+    "zh:96c4528bf9c16edb8841b68479ec51c499ed7fa680462fa28caeab3fc168bb43",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:cdc0b47ff840d708fbf75abfe86d23dc7f1dffdd233a771822a17b5c637f4769",
+    "zh:d9a9583e82776d1ebb6cf6c3d47acc2b302f8778f470ceffe7579dc794eb1feb",
+    "zh:e9367ca9f6f6418a23cdf8d01f29dd0c4f614e78499f52a767a422e4c334b915",
+    "zh:f6d355a2fb3bcebb597f68bbca4fa2aaa364efd29240236c582375e219d77656",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version = "4.0.4"
+  hashes = [
+    "h1:pe9vq86dZZKCm+8k1RhzARwENslF3SXb9ErHbQfgjXU=",
+    "zh:23671ed83e1fcf79745534841e10291bbf34046b27d6e68a5d0aab77206f4a55",
+    "zh:45292421211ffd9e8e3eb3655677700e3c5047f71d8f7650d2ce30242335f848",
+    "zh:59fedb519f4433c0fdb1d58b27c210b27415fddd0cd73c5312530b4309c088be",
+    "zh:5a8eec2409a9ff7cd0758a9d818c74bcba92a240e6c5e54b99df68fff312bbd5",
+    "zh:5e6a4b39f3171f53292ab88058a59e64825f2b842760a4869e64dc1dc093d1fe",
+    "zh:810547d0bf9311d21c81cc306126d3547e7bd3f194fc295836acf164b9f8424e",
+    "zh:824a5f3617624243bed0259d7dd37d76017097dc3193dac669be342b90b2ab48",
+    "zh:9361ccc7048be5dcbc2fafe2d8216939765b3160bd52734f7a9fd917a39ecbd8",
+    "zh:aa02ea625aaf672e649296bce7580f62d724268189fe9ad7c1b36bb0fa12fa60",
+    "zh:c71b4cd40d6ec7815dfeefd57d88bc592c0c42f5e5858dcc88245d371b4b8b1e",
+    "zh:dabcd52f36b43d250a3d71ad7abfa07b5622c69068d989e60b79b2bb4f220316",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terragrunt/org_account/sentinel_oidc/iam.tf
+++ b/terragrunt/org_account/sentinel_oidc/iam.tf
@@ -1,0 +1,30 @@
+# aws_iam_role.sentinel_oidc:
+
+resource "aws_iam_role" "sentinel_oidc" {
+  assume_role_policy = jsonencode(
+    {
+      Statement = [
+        {
+          Action = "sts:AssumeRoleWithWebIdentity"
+          Condition = {
+            StringEquals = {
+              "${local.url}:aud" = local.azure_client_id
+            }
+          }
+          Effect = "Allow"
+          Principal = {
+            Federated = aws_iam_openid_connect_provider.azure.arn
+          }
+        },
+      ]
+      Version = "2012-10-17"
+    }
+  )
+  description = "for sentinel function apps"
+  name        = "Sentinel-OIDC-Organizations-ReadOnly"
+}
+
+resource "aws_iam_role_policy_attachment" "sentinel_role_attachment" {
+  policy_arn = "arn:aws:iam::aws:policy/AWSOrganizationsReadOnlyAccess"
+  role       = aws_iam_role.sentinel_oidc.name
+}

--- a/terragrunt/org_account/sentinel_oidc/idp.tf
+++ b/terragrunt/org_account/sentinel_oidc/idp.tf
@@ -1,0 +1,21 @@
+locals {
+  azure_tenet_id  = "221ca1d3-b3f2-4346-8abc-88f802495c7d"
+  azure_client_id = "c8b9cf86-e2b4-4428-b356-14313412a4d1"
+  url             = "sts.windows.net/${local.azure_tenet_id}/"
+  url_https       = "https://${local.url}"
+}
+
+data "tls_certificate" "thumprint" {
+  url = local.url_https
+}
+
+# aws_iam_openid_connect_provider.azure:
+resource "aws_iam_openid_connect_provider" "azure" {
+  client_id_list = [
+    local.azure_client_id,
+  ]
+  thumbprint_list = [
+    data.tls_certificate.thumprint.certificates.0.sha1_fingerprint,
+  ]
+  url = local.url_https
+}

--- a/terragrunt/org_account/sentinel_oidc/terragrunt.hcl
+++ b/terragrunt/org_account/sentinel_oidc/terragrunt.hcl
@@ -1,0 +1,3 @@
+include {
+  path = find_in_parent_folders()
+}


### PR DESCRIPTION
# Summary | Résumé

This PR saves these resources created by clickOps:
- an OICD identity provider 
- an IAM role
- a role policy attachment 

Resources have been imported already.  This resolves cds-snc/create_watchlist#8
