### PR TITLE
fix: remove positive sns topic

### DIFF
--- a/terragrunt/aft/notifications/aft-notifications.tf
+++ b/terragrunt/aft/notifications/aft-notifications.tf
@@ -6,14 +6,12 @@ module "aft_failure_notifications" {
   slack_webhook_url = var.aft_notifications_hook
 
   sns_topic_arns = [
-    "arn:aws:sns:ca-central-1:137554749751:aft-failure-notifications",
-    "arn:aws:sns:ca-central-1:137554749751:aft-notifications"
+    "arn:aws:sns:ca-central-1:137554749751:aft-failure-notifications"
   ]
 
   billing_tag_value = var.billing_code
 
 }
-
 
 data "aws_sns_topic" "aft_failure_notifications" {
   name = "aft-failure-notifications"
@@ -21,17 +19,6 @@ data "aws_sns_topic" "aft_failure_notifications" {
 
 resource "aws_sns_topic_subscription" "aft_failure_notifications" {
   topic_arn = data.aws_sns_topic.aft_failure_notifications.arn
-  protocol  = "lambda"
-  endpoint  = module.aft_failure_notifications.lambda_arn
-}
-
-
-data "aws_sns_topic" "aft_notifications" {
-  name = "aft-notifications"
-}
-
-resource "aws_sns_topic_subscription" "aft_notifications" {
-  topic_arn = data.aws_sns_topic.aft_notifications.arn
   protocol  = "lambda"
   endpoint  = module.aft_failure_notifications.lambda_arn
 }


### PR DESCRIPTION
# Summary | Résumé

This SNS topic is way too noisy we should only really subscribe to the negative one, if we want to listen to positive we should change how we do it.
