### PR TITLE
feat: add a role that can list account ids

### DIFF
--- a/terragrunt/org_account/roles/.terraform.lock.hcl
+++ b/terragrunt/org_account/roles/.terraform.lock.hcl
@@ -1,0 +1,44 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.48.0"
+  constraints = ">= 4.40.0, < 5.0.0"
+  hashes = [
+    "h1:t/R3B4mibkp2zLer4MfhFbwHAVLAq71mJz4nwdUydBE=",
+    "zh:08f5e3c5256a4fbd5c988863d10e5279172b2470fec6d4fb13c372663e7f7cac",
+    "zh:2a04376b7fa84681bd2938973c7d0822c8c0f0656a4e7661a2f50ac4d852d4a3",
+    "zh:30d6cdf321aaba874934cbde505333d89d172d8d5ffcf40b6e66626c57bc6ab2",
+    "zh:364639ee19cf4cfaa65de84a2a71d32725d5b728b71dd88d01ccb639c006c1cf",
+    "zh:4e02252cd88b6f59f556f49c5ce46a358046c98f069230358ac15f4030ae1e76",
+    "zh:611717320f20b3512ceb90abddd5198a85e1093965ce59e3ef8183188c84f8c3",
+    "zh:630be3b9ba5b3a95ecb2ce2f3523714ab37cd8bcd7479c879a769e6a446ab5ed",
+    "zh:6701f9d3ae1ffadb3ebefbe75c9d82668cc5495b8f826e498adb8530e202b652",
+    "zh:6dc6fdfa7469c9de7b405c68b2f6a09a3438db1ef09d348e49c7ceff4300b01a",
+    "zh:84c8140d8af6965fa9cd80e52eb2ee3d273e3ab7762719a8d1af665c08fab748",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9b6b4f7d4cea37ba7a42a47d506115498858bcd6440ad97dfb214c13a688ba90",
+    "zh:a7f876af20f5c5dae8e333ec0dfc901e26aa801137e7df65fb365565637bbfe2",
+    "zh:ad107b8e11dd0609b856584ce70ae6621aa4f1f946da51f7c792f1259e3f9c27",
+    "zh:d5dc1683693a5fe2652952f50dbbeccd02716799c26c6d1a1378b226cf845e9b",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version = "4.0.4"
+  hashes = [
+    "h1:Wd3RqmQW60k2QWPN4sK5CtjGuO1d+CRNXgC+D4rKtXc=",
+    "zh:23671ed83e1fcf79745534841e10291bbf34046b27d6e68a5d0aab77206f4a55",
+    "zh:45292421211ffd9e8e3eb3655677700e3c5047f71d8f7650d2ce30242335f848",
+    "zh:59fedb519f4433c0fdb1d58b27c210b27415fddd0cd73c5312530b4309c088be",
+    "zh:5a8eec2409a9ff7cd0758a9d818c74bcba92a240e6c5e54b99df68fff312bbd5",
+    "zh:5e6a4b39f3171f53292ab88058a59e64825f2b842760a4869e64dc1dc093d1fe",
+    "zh:810547d0bf9311d21c81cc306126d3547e7bd3f194fc295836acf164b9f8424e",
+    "zh:824a5f3617624243bed0259d7dd37d76017097dc3193dac669be342b90b2ab48",
+    "zh:9361ccc7048be5dcbc2fafe2d8216939765b3160bd52734f7a9fd917a39ecbd8",
+    "zh:aa02ea625aaf672e649296bce7580f62d724268189fe9ad7c1b36bb0fa12fa60",
+    "zh:c71b4cd40d6ec7815dfeefd57d88bc592c0c42f5e5858dcc88245d371b4b8b1e",
+    "zh:dabcd52f36b43d250a3d71ad7abfa07b5622c69068d989e60b79b2bb4f220316",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terragrunt/org_account/roles/cartography.tf
+++ b/terragrunt/org_account/roles/cartography.tf
@@ -1,0 +1,41 @@
+locals { 
+  cartographyOrgListNamesname = "cartographyOrgListIds" 
+}
+
+# Plan Assume Role
+module "assume_plan_role" {
+  source                = "../../modules/assume_role"
+  role_name             = "assumeCartographyOrg"
+  org_account           = 794722365809 ## Not org account it's the account the role that is assuming this role sits in
+  org_account_role_name = local.cartographyOrgListNamesname ## Not the org account role name but the name of the role assuming this role
+  assume_policy_name    = "AssumePlanRole"
+  billing_tag_value     = var.billing_code
+}
+
+# An IAM policy document that allows you to query all the accounts in an org
+data "aws_iam_policy_document" "org_account_list" {
+  statement {
+    sid = "ListAccountsInOrg"
+
+    effect = "Allow"
+
+    actions = [
+      "organizations:ListAccounts",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "org_account_list_in_sandbox" {
+  name   = "ListAccountsInOrg"
+  policy = data.aws_iam_policy_document.org_account_list.json
+}
+
+# Attach the policy document to the role loca.org_account_list_name
+resource "aws_iam_role_policy_attachment" "attach_list_accounts_in_sandbox" {
+  role       = local.org_account_list_name
+  policy_arn = aws_iam_policy.org_account_list_in_sandbox.arn
+}

--- a/terragrunt/org_account/roles/cartography.tf
+++ b/terragrunt/org_account/roles/cartography.tf
@@ -1,12 +1,12 @@
-locals { 
-  cartographyOrgListNamesname = "cartographyOrgListIds" 
+locals {
+  cartographyOrgListNamesname = "cartographyOrgListIds"
 }
 
 # Plan Assume Role
 module "assume_plan_role" {
   source                = "../../modules/assume_role"
   role_name             = "assumeCartographyOrg"
-  org_account           = 794722365809 ## Not org account it's the account the role that is assuming this role sits in
+  org_account           = 794722365809                      ## Not org account it's the account the role that is assuming this role sits in
   org_account_role_name = local.cartographyOrgListNamesname ## Not the org account role name but the name of the role assuming this role
   assume_policy_name    = "AssumePlanRole"
   billing_tag_value     = var.billing_code

--- a/terragrunt/org_account/roles/cartography.tf
+++ b/terragrunt/org_account/roles/cartography.tf
@@ -29,13 +29,13 @@ data "aws_iam_policy_document" "org_account_list" {
   }
 }
 
-resource "aws_iam_policy" "org_account_list_in_sandbox" {
+resource "aws_iam_policy" "org_account_list" {
   name   = "ListAccountsInOrg"
   policy = data.aws_iam_policy_document.org_account_list.json
 }
 
 # Attach the policy document to the role loca.org_account_list_name
-resource "aws_iam_role_policy_attachment" "attach_list_accounts_in_sandbox" {
+resource "aws_iam_role_policy_attachment" "attach_list_accounts" {
   role       = local.org_account_list_name
-  policy_arn = aws_iam_policy.org_account_list_in_sandbox.arn
+  policy_arn = aws_iam_policy.org_account_list.arn
 }


### PR DESCRIPTION
# Summary | Résumé

This role is going to be used by the cartography state machine so that
it can get the list of account ids.


