### PR TITLE
feat: allow roles to assume for local apply/plan

### DIFF
--- a/terragrunt/modules/assume_role/inputs.tf
+++ b/terragrunt/modules/assume_role/inputs.tf
@@ -28,3 +28,9 @@ variable "billing_tag_value" {
   type        = string
   description = "The value of the tag to be used for billing purposes"
 }
+
+variable "extra_roles" {
+  type        = list(string)
+  description = "A list of extra roles that can assume this role"
+  default     = []
+}

--- a/terragrunt/modules/assume_role/main.tf
+++ b/terragrunt/modules/assume_role/main.tf
@@ -14,11 +14,8 @@ data "aws_iam_policy_document" "this" {
   statement {
     actions = ["sts:AssumeRole"]
     principals {
-      type = "AWS"
-      identifiers = [
-        "arn:aws:iam::${var.org_account}:role/${var.org_account_role_name}",
-        "arn:aws:iam::${var.org_account}:user/CalvinRodo"
-      ] # Will only be here as long as I need to debug TF locally.
+      type        = "AWS"
+      identifiers = concat(["arn:aws:iam::${var.org_account}:role/${var.org_account_role_name}"], var.extra_roles)
     }
   }
 }


### PR DESCRIPTION
# Summary | Résumé

Previously I had hardcoded my personal IAM User into the module in order
to allow me to plan/apply from my local machine.

This change will allow us to pass in an arbitrary number of roles, it
also allows us to easily add or remove roles without having to mess with
the module, so we can open PR's only as long as we require the ability
to do local work.

I'm also removing my personal IAM User as I don't need to assume any roles at the moment


