### PR TITLE
fix: change role name for nuke account id read

### DIFF
--- a/terragrunt/org_account/roles/OIDC.tf
+++ b/terragrunt/org_account/roles/OIDC.tf
@@ -1,5 +1,5 @@
 locals {
-  org_account_list_name = "listAccountsInOrg"
+  org_account_list_name = "listAccountsInSandboxOUForNuke"
 }
 
 module "OIDC_Roles" {


### PR DESCRIPTION
# Summary | Résumé

The name of the role used by the nuke action to list all the accounts in
the Sandbox OU is incorrect, it doesn't list all the accounts in an ORG
just the accounts in the sandbox OU.

I am trying to make a role that allows listing all accounts in the org
and so this is causing an issue with name collision.

This should fix it, and I will need to pair it with a PR that fixes the
role in the nuke action.


