### PR TITLE
fix: add vulnerability report IAM permissions

### DIFF
--- a/terragrunt/log_archive/sre_bot/sre_vulnerability_report.tf
+++ b/terragrunt/log_archive/sre_bot/sre_vulnerability_report.tf
@@ -31,7 +31,8 @@ data "aws_iam_policy_document" "sre_vulnerability_report" {
     sid    = "ReadGuardDuty"
     effect = "Allow"
     actions = [
-      "guardduty:GetFindingsStatistics",
+      "guardduty:GetFindings",
+      "guardduty:ListFindings",
       "guardduty:ListDetectors",
     ]
     resources = ["*"]


### PR DESCRIPTION
# Summary
Update the GuardDuty IAM permissions to allow for retrieval of GuardDuty findings.

# Related
- cds-snc/site-reliability-engineering#738