### PR TITLE
feat: add SCP to block EC2 for scratch accounts

### DIFF
--- a/terragrunt/org_account/organization/scp.tf
+++ b/terragrunt/org_account/organization/scp.tf
@@ -87,6 +87,17 @@ data "aws_iam_policy_document" "cds_snc_universal_guardrails" {
       "*"
     ]
   }
+
+  statement {
+    sid = "BlockEC2ForScratch"
+    effect = "Deny"
+    actions = [
+      "ec2:*"
+    ]
+    resources = [
+      "arn:aws:organizations::659087519042:ou/o-625no8z3dd/ou-5gsq-qhvjdryl",
+    ]
+  }
 }
 
 resource "aws_organizations_policy" "cds_snc_universal_guardrails" {


### PR DESCRIPTION
# Summary | Résumé

Adding an SCP to block the use of EC2 for all scratch accounts.

Using the OU as the resource.