### PR TITLE
fix: format ops passwords + length

### DIFF
--- a/bin/create_ops_users.sh
+++ b/bin/create_ops_users.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-lpass status
-if [ $? -ne 0 ]; then 
+if ! lpass status; then 
   echo "Error: Must be logged in lpass"
   exit 1
 fi
 
+NOW=$(date)
 ACCOUNT_ID=$(aws sts get-caller-identity --query 'Account' --output text)
 
 aws iam create-group --group-name admins
@@ -13,20 +13,22 @@ aws iam attach-group-policy --policy-arn arn:aws:iam::aws:policy/AdministratorAc
 
 aws iam create-user --user-name ops1
 aws iam add-user-to-group --user-name ops1 --group-name admins
-OPS1PWORD=$(aws secretsmanager get-random-password --region ca-central-1 | jq -r '.RandomPassword')
+OPS1PWORD=$(aws secretsmanager get-random-password --region ca-central-1 --password-length 64 | jq -r '.RandomPassword')
 aws iam create-login-profile --user-name ops1 --password "$OPS1PWORD"
 
 aws iam create-user --user-name ops2
 aws iam add-user-to-group --user-name ops2 --group-name admins
-OPS2PWORD=$(aws secretsmanager get-random-password --region ca-central-1 | jq -r '.RandomPassword')
+OPS2PWORD=$(aws secretsmanager get-random-password --region ca-central-1 --password-length 64 | jq -r '.RandomPassword')
 aws iam create-login-profile --user-name ops2 --password "$OPS2PWORD"
 
 lpass add --notes "Shared-SRE - AWS Cloud credentials/Control Tower/$ACCOUNT_ID" --non-interactive --sync=now <<EOF
+~~~~~~
+Updated on: $NOW
 
 uname: ops1
 pword: $OPS1PWORD
 
 uname: ops2
 pword: $OPS2PWORD
-
+~~~~~~
 EOF


### PR DESCRIPTION
# Summary | Résumé

Updating the script to:
- Format LastPass notes based on current standard
- Get 64 character password from AWS Secrets Manager
