### PR TITLE
feat: enable trusted access

### DIFF
--- a/terragrunt/org_account/organization/guardrails.tf
+++ b/terragrunt/org_account/organization/guardrails.tf
@@ -46,7 +46,6 @@ module "REQUIRE_CLOUDTRAIL_LOG_FILE_VALIDATION" {
   ou_arns = [
     aws_organizations_organizational_unit.Test.arn,
     aws_organizations_organizational_unit.SRETools.arn,
-    aws_organizations_organizational_unit.Security.arn,
     aws_organizations_organizational_unit.Sandbox.arn,
     aws_organizations_organizational_unit.DumpsterFire.arn,
     aws_organizations_organizational_unit.AFT.arn,

--- a/terragrunt/org_account/organization/organizations.tf
+++ b/terragrunt/org_account/organization/organizations.tf
@@ -7,7 +7,8 @@ resource "aws_organizations_organization" "org_config" {
     "controltower.amazonaws.com", # Enabled by Control Tower
     "guardduty.amazonaws.com",
     "securityhub.amazonaws.com",
-    "reporting.trustedadvisor.amazonaws.com"
+    "reporting.trustedadvisor.amazonaws.com",
+    "account.amazonaws.com" # https://docs.aws.amazon.com/accounts/latest/reference/using-orgs-trusted-access.html
   ]
 
   enabled_policy_types = [


### PR DESCRIPTION
# Summary | Résumé

This enables trusted access in the organization which will allow org admins to modify account information from the organization account. 


https://docs.aws.amazon.com/accounts/latest/reference/manage-acct-update-contact-primary.html

This will allow me to change the phone number associated with any account thus allowing me to fix this issue: https://github.com/cds-snc/site-reliability-engineering/issues/798 without having to bug internal ops folks to sit in a meeting with me while I change MFA on the account. 


