### PR TITLE
feat: add an SCP on the root user.

### DIFF
--- a/terragrunt/org_account/organization/scp.tf
+++ b/terragrunt/org_account/organization/scp.tf
@@ -87,6 +87,60 @@ data "aws_iam_policy_document" "cds_snc_universal_guardrails" {
       "*"
     ]
   }
+
+  statement {
+    sid = "DenyRootActions"
+    effect = "Deny"
+    actions = [
+      "*" # Deny all actions
+    ]
+    not_actions = [
+
+
+      ## Allow Account Actions for accounts created before Mar 6 2023
+      ## see https://docs.aws.amazon.com/accounts/latest/reference/security_account-permissions-ref.html
+      "aws-portal:*",
+
+      ## Allow changing of account settings
+      "account:PutChallengeQuestions",
+      "account:CloseAccount",
+      "account:PutContactInformation",
+      "account:Get*",
+      "account:List*",
+
+      ## Allow changing of account name 
+      "iam:UpdateAccountName",
+
+      ### Enable MFA 
+      "iam:CreateVirtualMFADevice",
+      "iam:EnableMFADevice",
+      "iam:GetUser",
+      "iam:ListMFADevices",
+      "iam:ListVirtualMFADevices",
+      "iam:ResyncMFADevice",
+      "iam:DeleteVirtualMFADevice",
+
+
+      ## Allow us to attach admin to the IAM Users accounts if required
+      "iam:GetPolicy",
+      "iam:ListPolicies",
+      "iam:PutPolicy",
+      "iam:AttachUserPolicy",
+      "iam:ListAttachedUserPolicies",
+      "iam:AttachGroupPolicy",
+      "iam:ListAttachedGroupPolicies",
+
+      "sts:GetSessionToken",
+
+    ]
+    resources = ["*"]
+    condition {
+      test    = "StringLike"
+      variable = "aws:PrincipalArn"
+      values   = ["arn:aws:iam::*:root"]
+    }
+  }
+
 }
 
 resource "aws_organizations_policy" "cds_snc_universal_guardrails" {

--- a/terragrunt/org_account/organization/scp.tf
+++ b/terragrunt/org_account/organization/scp.tf
@@ -89,7 +89,7 @@ data "aws_iam_policy_document" "cds_snc_universal_guardrails" {
   }
 
   statement {
-    sid = "DenyRootActions"
+    sid    = "DenyRootActions"
     effect = "Deny"
     actions = [
       "*" # Deny all actions
@@ -135,7 +135,7 @@ data "aws_iam_policy_document" "cds_snc_universal_guardrails" {
     ]
     resources = ["*"]
     condition {
-      test    = "StringLike"
+      test     = "StringLike"
       variable = "aws:PrincipalArn"
       values   = ["arn:aws:iam::*:root"]
     }


### PR DESCRIPTION
# Summary | Résumé

This prevents the SCP user from performing any action except for the few
identified here: https://docs.aws.amazon.com/accounts/latest/reference/root-user-tasks.html

Well some of them, obviously there are some tasks we will never do like
sell on the market place or sign up for AWS GovCloud (US)

Some of these taks were grabbed from the ASEA Root SCP: https://github.com/aws-samples/aws-secure-environment-accelerator/blob/main/reference-artifacts/SCPs/ASEA-Guardrails-Sensitive.json#L21-L42

closes https://github.com/cds-snc/security-risk-register/issues/15
closes https://github.com/cds-snc/site-reliability-engineering/issues/755
