### PR TITLE
feat: stop alerting on aft-failure-notifications

### DIFF
--- a/terragrunt/aft/notifications/aft-notifications.tf
+++ b/terragrunt/aft/notifications/aft-notifications.tf
@@ -1,24 +1,24 @@
-module "aft_failure_notifications" {
-  source = "github.com/cds-snc/terraform-modules?ref=v3.0.17//notify_slack"
+# module "aft_failure_notifications" {
+#   source = "github.com/cds-snc/terraform-modules?ref=v3.0.17//notify_slack"
 
-  function_name     = "slack_notifier_aft"
-  project_name      = "AFT"
-  slack_webhook_url = var.aft_notifications_hook
+#   function_name     = "slack_notifier_aft"
+#   project_name      = "AFT"
+#   slack_webhook_url = var.aft_notifications_hook
 
-  sns_topic_arns = [
-    "arn:aws:sns:ca-central-1:137554749751:aft-failure-notifications"
-  ]
+#   sns_topic_arns = [
+#     "arn:aws:sns:ca-central-1:137554749751:aft-failure-notifications"
+#   ]
 
-  billing_tag_value = var.billing_code
+#   billing_tag_value = var.billing_code
 
-}
+# }
 
-data "aws_sns_topic" "aft_failure_notifications" {
-  name = "aft-failure-notifications"
-}
+# data "aws_sns_topic" "aft_failure_notifications" {
+#   name = "aft-failure-notifications"
+# }
 
-resource "aws_sns_topic_subscription" "aft_failure_notifications" {
-  topic_arn = data.aws_sns_topic.aft_failure_notifications.arn
-  protocol  = "lambda"
-  endpoint  = module.aft_failure_notifications.lambda_arn
-}
+# resource "aws_sns_topic_subscription" "aft_failure_notifications" {
+#   topic_arn = data.aws_sns_topic.aft_failure_notifications.arn
+#   protocol  = "lambda"
+#   endpoint  = module.aft_failure_notifications.lambda_arn
+# }


### PR DESCRIPTION
# Summary | Résumé

Because of an overly noisy sns topic we are getting alerts on expected behaviours not failures, so I'm turning this off until it is hopefully addressed. 

Closes #182
