### PR TITLE
feat: enable trusted access to CF Stacksets

### DIFF
--- a/terragrunt/org_account/organization/organizations.tf
+++ b/terragrunt/org_account/organization/organizations.tf
@@ -8,7 +8,7 @@ resource "aws_organizations_organization" "org_config" {
     "guardduty.amazonaws.com",
     "securityhub.amazonaws.com",
     "reporting.trustedadvisor.amazonaws.com",
-    "account.amazonaws.com", # https://docs.aws.amazon.com/accounts/latest/reference/using-orgs-trusted-access.html
+    "account.amazonaws.com",                 # https://docs.aws.amazon.com/accounts/latest/reference/using-orgs-trusted-access.html
     "stacksets.cloudformation.amazonaws.com" # Enabling to allow CT to re-register OUs
   ]
 

--- a/terragrunt/org_account/organization/organizations.tf
+++ b/terragrunt/org_account/organization/organizations.tf
@@ -8,7 +8,8 @@ resource "aws_organizations_organization" "org_config" {
     "guardduty.amazonaws.com",
     "securityhub.amazonaws.com",
     "reporting.trustedadvisor.amazonaws.com",
-    "account.amazonaws.com" # https://docs.aws.amazon.com/accounts/latest/reference/using-orgs-trusted-access.html
+    "account.amazonaws.com", # https://docs.aws.amazon.com/accounts/latest/reference/using-orgs-trusted-access.html
+    "stacksets.cloudformation.amazonaws.com" # Enabling to allow CT to re-register OUs
   ]
 
   enabled_policy_types = [


### PR DESCRIPTION
# Summary | Résumé

This is required to re-register an OU in Control Tower.

We recieved the following error when trying to register.

>Account enrollment failed.
AWS Control Tower could not enroll your account for the following reason: AWS Control Tower operation failed because trusted access for AWS CloudFormation was disabled. Please enable trusted access using the AWS CloudFormation console.

Docs for enabling this: https://docs.aws.amazon.com/organizations/latest/userguide/services-that-can-integrate-cloudformation.html


Related to #181


