### PR TITLE
feat: upgrade aft to 1.9.0 and TF to latest patch

### DIFF
--- a/terragrunt/org_account/aft/main.tf
+++ b/terragrunt/org_account/aft/main.tf
@@ -1,7 +1,7 @@
 module "account_factory_for_terraform" {
-  source = "github.com/aws-ia/terraform-aws-control_tower_account_factory?ref=1.7.0"
+  source = "github.com/aws-ia/terraform-aws-control_tower_account_factory?ref=1.9.0"
 
-  terraform_version = "1.3.6"
+  terraform_version = "1.3.9"
 
   vcs_provider                                  = "github"
   account_customizations_repo_name              = "cds-snc/aft-account-customizations"


### PR DESCRIPTION
# Summary | Résumé

Account factory for terraform 1.9.0 fixes the issue with too many errors
going to the aft-failure-notification sns topic.

And just upgraded to the latest version of 1.3.9

Closes #186 