### PR TITLE
feat: add temp SCP for Cartography execution

### DIFF
--- a/terragrunt/org_account/organization/organizations.tf
+++ b/terragrunt/org_account/organization/organizations.tf
@@ -54,6 +54,11 @@ resource "aws_organizations_policy_attachment" "Sandbox-cds_snc_universal_guardr
   target_id = aws_organizations_organizational_unit.Sandbox.id
 }
 
+resource "aws_organizations_policy_attachment" "Test-cartography_tmp_scp" {
+  policy_id = aws_organizations_policy.cartography_tmp_scp.id
+  target_id = aws_organizations_organizational_unit.Test.id
+}
+
 resource "aws_organizations_organizational_unit" "Security" {
   name      = "Security"
   parent_id = local.root

--- a/terragrunt/org_account/organization/scp.tf
+++ b/terragrunt/org_account/organization/scp.tf
@@ -81,7 +81,7 @@ data "aws_iam_policy_document" "cartography_tmp_scp" {
       "waf:*",
       "wafv2:*"
     ]
-    resources = "*"
+    resources = ["*"]
     condition {
       test     = "StringNotEquals"
       variable = "aws:RequestedRegion"

--- a/terragrunt/org_account/organization/scp.tf
+++ b/terragrunt/org_account/organization/scp.tf
@@ -146,6 +146,7 @@ data "aws_iam_policy_document" "cartography_tmp_scp" {
         "arn:aws:iam::*:role/AWSAFTExecution"
       ]
     }
+  }
 }
 
 resource "aws_organizations_policy" "cartography_tmp_scp" {

--- a/terragrunt/org_account/organization/scp.tf
+++ b/terragrunt/org_account/organization/scp.tf
@@ -135,7 +135,7 @@ data "aws_iam_policy_document" "cartography_tmp_scp" {
     effect = "Deny"
     actions = [
       "iam:CreateAccessKey",
-     ]
+    ]
     resources = [
       "arn:aws:iam::*:role/secopsAssetInventorySecurityAuditRole"
     ]

--- a/terragrunt/org_account/organization/scp.tf
+++ b/terragrunt/org_account/organization/scp.tf
@@ -129,6 +129,23 @@ data "aws_iam_policy_document" "cartography_tmp_scp" {
       ]
     }
   }
+
+  statement {
+    sid    = "PreventIAMAccessKeyCreation"
+    effect = "Deny"
+    actions = [
+      "iam:CreateAccessKey",
+     ]
+    resources = [
+      "arn:aws:iam::*:role/secopsAssetInventorySecurityAuditRole"
+    ]
+    condition {
+      test     = "ArnNotLike"
+      variable = "aws:PrincipalArn"
+      values = [
+        "arn:aws:iam::*:role/AWSAFTExecution"
+      ]
+    }
 }
 
 resource "aws_organizations_policy" "cartography_tmp_scp" {

--- a/terragrunt/org_account/organization/scp.tf
+++ b/terragrunt/org_account/organization/scp.tf
@@ -1,3 +1,111 @@
+data "aws_iam_policy_document" "cartography_tmp_scp" {
+  statement {
+    sid    = "GRREGIONDENYreplication"
+    effect = "Deny"
+    not_actions = [
+      "a4b:*",
+      "access-analyzer:*",
+      "acm:*",
+      "account:*",
+      "activate:*",
+      "artifact:*",
+      "aws-marketplace-management:*",
+      "aws-marketplace:*",
+      "aws-portal:*",
+      "billingconductor:*",
+      "budgets:*",
+      "ce:*",
+      "chatbot:*",
+      "chime:*",
+      "cloudfront:*",
+      "compute-optimizer:*",
+      "config:*",
+      "cur:*",
+      "datapipeline:GetAccountLimits",
+      "devicefarm:*",
+      "directconnect:*",
+      "discovery-marketplace:*",
+      "ec2:DescribeRegions",
+      "ec2:DescribeTransitGateways",
+      "ec2:DescribeVpnGateways",
+      "ecr-public:*",
+      "fms:*",
+      "globalaccelerator:*",
+      "health:*",
+      "iam:*",
+      "importexport:*",
+      "kms:*",
+      "license-manager:ListReceivedLicenses",
+      "lightsail:Get*",
+      "mobileanalytics:*",
+      "networkmanager:*",
+      "organizations:*",
+      "pricing:*",
+      "resource-explorer-2:*",
+      "route53-recovery-cluster:*",
+      "route53-recovery-control-config:*",
+      "route53-recovery-readiness:*",
+      "route53:*",
+      "route53domains:*",
+      "s3:CreateMultiRegionAccessPoint",
+      "s3:DeleteMultiRegionAccessPoint",
+      "s3:DescribeMultiRegionAccessPointOperation",
+      "s3:GetAccountPublic",
+      "s3:GetAccountPublicAccessBlock",
+      "s3:GetBucketLocation",
+      "s3:GetBucketPolicyStatus",
+      "s3:GetBucketPublicAccessBlock",
+      "s3:GetMultiRegionAccessPoint",
+      "s3:GetMultiRegionAccessPointPolicy",
+      "s3:GetMultiRegionAccessPointPolicyStatus",
+      "s3:GetStorageLensConfiguration",
+      "s3:GetStorageLensDashboard",
+      "s3:ListAllMyBuckets",
+      "s3:ListMultiRegionAccessPoints",
+      "s3:ListStorageLensConfigurations",
+      "s3:PutAccountPublic",
+      "s3:PutAccountPublicAccessBlock",
+      "s3:PutMultiRegionAccessPointPolicy",
+      "savingsplans:*",
+      "shield:*",
+      "sso:*",
+      "sts:*",
+      "support:*",
+      "supportapp:*",
+      "supportplans:*",
+      "sustainability:*",
+      "tag:GetResources",
+      "trustedadvisor:*",
+      "vendor-insights:ListEntitledSecurityProfiles",
+      "waf-regional:*",
+      "waf:*",
+      "wafv2:*"
+    ]
+    resources = "*"
+    condition {
+      test     = "StringNotEquals"
+      variable = "aws:RequestedRegion"
+      values = [
+        "us-east-1",
+        "us-west-2",
+        "ca-central-1",
+      ]
+    }
+    condition {
+      test     = "ArnNotLike"
+      variable = "aws:PrincipalArn"
+      values = ["arn:aws:iam::*:role/AWSControlTowerExecution",
+      "arn:aws:iam::*:role/secopsAssetInventorySecurityAuditRole"]
+    }
+  }
+}
+
+resource "aws_organizations_policy" "cartography_tmp_scp" {
+  name    = "Cartography Temporary SCP"
+  type    = "SERVICE_CONTROL_POLICY"
+  content = data.aws_iam_policy_document.cartography_tmp_scp.json
+}
+
 data "aws_iam_policy_document" "cds_snc_universal_guardrails" {
   statement {
     sid    = "BlockRedshift"

--- a/terragrunt/org_account/organization/scp.tf
+++ b/terragrunt/org_account/organization/scp.tf
@@ -98,7 +98,7 @@ data "aws_iam_policy_document" "cartography_tmp_scp" {
       "arn:aws:iam::*:role/secopsAssetInventorySecurityAuditRole"]
     }
   }
-  # Create a policy statement that prevents the modification of the IAM role secopsAssetInventoryCartographyRole
+
   statement {
     sid    = "PreventIAMRoleModifications"
     effect = "Deny"
@@ -119,13 +119,13 @@ data "aws_iam_policy_document" "cartography_tmp_scp" {
       "iam:UpdateRolePolicy"
     ]
     resources = [
-      "arn:aws:iam::*:role/secopsAssetInventoryCartographyRole"
+      "arn:aws:iam::*:role/secopsAssetInventorySecurityAuditRole"
     ]
     condition {
       test     = "ArnNotLike"
       variable = "aws:PrincipalArn"
       values = [
-        "arn:aws:iam::*:role/AWSControlTowerExecution"
+        "arn:aws:iam::*:role/AWSAFTExecution"
       ]
     }
   }

--- a/terragrunt/org_account/organization/scp.tf
+++ b/terragrunt/org_account/organization/scp.tf
@@ -98,6 +98,37 @@ data "aws_iam_policy_document" "cartography_tmp_scp" {
       "arn:aws:iam::*:role/secopsAssetInventorySecurityAuditRole"]
     }
   }
+  # Create a policy statement that prevents the modification of the IAM role secopsAssetInventoryCartographyRole
+  statement {
+    sid    = "PreventIAMRoleModifications"
+    effect = "Deny"
+    actions = [
+      "iam:AttachRolePolicy",
+      "iam:CreatePolicy",
+      "iam:CreatePolicyVersion",
+      "iam:CreateRole",
+      "iam:DeletePolicy",
+      "iam:DeletePolicyVersion",
+      "iam:DeleteRole",
+      "iam:DeleteRolePolicy",
+      "iam:DetachRolePolicy",
+      "iam:PutRolePolicy",
+      "iam:UpdateAssumeRolePolicy",
+      "iam:UpdateRole",
+      "iam:UpdateRoleDescription",
+      "iam:UpdateRolePolicy"
+    ]
+    resources = [
+      "arn:aws:iam::*:role/secopsAssetInventoryCartographyRole"
+    ]
+    condition {
+      test     = "ArnNotLike"
+      variable = "aws:PrincipalArn"
+      values = [
+        "arn:aws:iam::*:role/AWSControlTowerExecution"
+      ]
+    }
+  }
 }
 
 resource "aws_organizations_policy" "cartography_tmp_scp" {


### PR DESCRIPTION
# Summary | Résumé

Setting up temporary SCPs to grant specific and limited permissions to run Cartography for asset inventory.

It should:
- Replicate the Control Tower's default [Deny Region SCP](https://docs.aws.amazon.com/controltower/latest/userguide/data-residency-controls.html#primary-region-deny-policy) and include the `secopsAssetInventorySecurityAuditRole` role
- Prevent the creation of access keys for the `secopsAssetInventorySecurityAuditRole` role
- Prevent all modifications to the `secopsAssetInventorySecurityAuditRole` role except by `AWSAFTExecution` role

Fixes https://github.com/cds-snc/site-reliability-engineering/issues/830 