### PR TITLE
feat: upgrade aft to 1.10.3

### DIFF
--- a/terragrunt/org_account/aft/main.tf
+++ b/terragrunt/org_account/aft/main.tf
@@ -1,5 +1,5 @@
 module "account_factory_for_terraform" {
-  source = "github.com/aws-ia/terraform-aws-control_tower_account_factory?ref=1.9.1"
+  source = "github.com/aws-ia/terraform-aws-control_tower_account_factory?ref=1.10.3"
 
   terraform_version = "1.3.9"
 


### PR DESCRIPTION
# Summary | Résumé

Upgrades AFT to the latest version 1.10.3

Docs for upgrade: 

https://github.com/aws-ia/terraform-aws-control_tower_account_factory/compare/1.9.1...1.10.3


This fix should address some compliance issues with the s3 buckets this thing creates 

>Amazon S3 now automatically enables S3 Block Public Access and disables the use of access control lists for all newly created buckets. Due to this change, the ACLs applied to AFT buckets have been removed.
