### PR TITLE
feat: add SCP statement to deny hosted zone delete

### DIFF
--- a/terragrunt/org_account/organization/scp.tf
+++ b/terragrunt/org_account/organization/scp.tf
@@ -295,6 +295,18 @@ data "aws_iam_policy_document" "cds_snc_universal_guardrails" {
     }
   }
 
+  statement {
+    sid    = "DenyDeleteHostedZone"
+    effect = "Deny"
+    actions = [
+      "route53:DeleteHostedZone",
+    ]
+    resources = [
+      "arn:aws:route53:::hostedzone/Z33C47YI9EN8XL",
+      "arn:aws:route53:::hostedzone/Z1XG153PQF3VV5",
+      "arn:aws:route53:::hostedzone/Z35N8HLYUZDWBH",
+    ]
+  }
 }
 
 resource "aws_organizations_policy" "cds_snc_universal_guardrails" {


### PR DESCRIPTION
# Summary
Prevent the deletion of specific Route53 hosted zones.