### PR TITLE
Changing references of terraform modules

### DIFF
--- a/terragrunt/aft/main/assume_roles.tf
+++ b/terragrunt/aft/main/assume_roles.tf
@@ -18,7 +18,7 @@ module "assume_plan_role" {
 }
 
 module "attach_tf_plan_policy_assume" {
-  source            = "github.com/cds-snc/terraform-modules?ref=v3.0.2//attach_tf_plan_policy"
+  source            = "github.com/cds-snc/terraform-modules//attach_tf_plan_policy?ref=v3.0.2"
   account_id        = data.aws_caller_identity.current.account_id
   role_name         = "assume_plan"
   bucket_name       = "${var.billing_code}-tf"

--- a/terragrunt/aft/main/main.tf
+++ b/terragrunt/aft/main/main.tf
@@ -1,4 +1,4 @@
 module "password_policy" {
-  source = "github.com/cds-snc/terraform-modules?ref=v3.0.2//aws_goc_password_policy"
+  source = "github.com/cds-snc/terraform-modules//aws_goc_password_policy?ref=v3.0.2"
 }
 

--- a/terragrunt/aft/main/slack_notify.tf
+++ b/terragrunt/aft/main/slack_notify.tf
@@ -1,5 +1,5 @@
 module "aft_slack_notification" {
-  source            = "github.com/cds-snc/terraform-modules?ref=v3.0.2//notify_slack"
+  source            = "github.com/cds-snc/terraform-modules//notify_slack?ref=v3.0.2"
   billing_tag_value = var.billing_code
   function_name     = "aft_slack_notification"
   project_name      = "Account Factory for Terraform"

--- a/terragrunt/aft/notifications/aft-notifications.tf
+++ b/terragrunt/aft/notifications/aft-notifications.tf
@@ -1,5 +1,5 @@
 module "aft_failure_notifications" {
-  source = "github.com/cds-snc/terraform-modules?ref=v3.0.17//notify_slack"
+  source = "github.com/cds-snc/terraform-modules//notify_slack?ref=v3.0.17"
 
   function_name     = "slack_notifier_aft"
   project_name      = "AFT"

--- a/terragrunt/audit/main/assume_roles.tf
+++ b/terragrunt/audit/main/assume_roles.tf
@@ -18,7 +18,7 @@ module "assume_plan_role" {
 }
 
 module "attach_tf_plan_policy_assume" {
-  source            = "github.com/cds-snc/terraform-modules?ref=v3.0.2//attach_tf_plan_policy"
+  source            = "github.com/cds-snc/terraform-modules//attach_tf_plan_policy?ref=v3.0.2"
   account_id        = data.aws_caller_identity.current.account_id
   role_name         = "assume_plan"
   bucket_name       = "${var.billing_code}-tf"

--- a/terragrunt/log_archive/legacy_archives/main.tf
+++ b/terragrunt/log_archive/legacy_archives/main.tf
@@ -1,5 +1,5 @@
 module "aws-landing-zone-logs_bucket" {
-  source = "github.com/cds-snc/terraform-modules?ref=v3.0.20//S3"
+  source = "github.com/cds-snc/terraform-modules//S3?ref=v3.0.20"
 
   bucket_name       = "legacy-aws-landing-zone-logs"
   billing_tag_value = var.billing_code
@@ -8,7 +8,7 @@ module "aws-landing-zone-logs_bucket" {
 }
 
 module "aws-landing-zone-s3-access-logs_bucket" {
-  source = "github.com/cds-snc/terraform-modules?ref=v3.0.20//S3"
+  source = "github.com/cds-snc/terraform-modules//S3?ref=v3.0.20"
 
   bucket_name       = "legacy-aws-landing-zone-s3-access-logs"
   billing_tag_value = var.billing_code

--- a/terragrunt/log_archive/main/assume_roles.tf
+++ b/terragrunt/log_archive/main/assume_roles.tf
@@ -17,7 +17,7 @@ module "assume_plan_role" {
 }
 
 module "attach_tf_plan_policy_assume" {
-  source            = "github.com/cds-snc/terraform-modules?ref=v3.0.2//attach_tf_plan_policy"
+  source            = "github.com/cds-snc/terraform-modules//attach_tf_plan_policy?ref=v3.0.2"
   account_id        = data.aws_caller_identity.current.account_id
   role_name         = "assume_plan"
   bucket_name       = "${var.billing_code}-tf"

--- a/terragrunt/log_archive/sre_bot/OIDC.tf
+++ b/terragrunt/log_archive/sre_bot/OIDC.tf
@@ -1,5 +1,5 @@
 module "OIDC_Roles" {
-  source      = "github.com/cds-snc/terraform-modules?ref=v5.0.0//gh_oidc_role"
+  source      = "github.com/cds-snc/terraform-modules//gh_oidc_role?ref=v5.0.0"
   oidc_exists = true
 
   roles = [{

--- a/terragrunt/org_account/main/alarms.tf
+++ b/terragrunt/org_account/main/alarms.tf
@@ -7,7 +7,7 @@ resource "aws_sns_topic" "warning" {
 }
 
 module "alarm_actions" {
-  source                = "github.com/cds-snc/terraform-modules?ref=v3.0.2//user_login_alarm"
+  source                = "github.com/cds-snc/terraform-modules//user_login_alarm?ref=v3.0.2"
   account_names         = ["Ops1", "Ops2"]
   log_group_name        = "aws-controltower/CloudTrailLogs"
   alarm_actions_success = [aws_sns_topic.critical.arn]

--- a/terragrunt/org_account/main/guardduty.tf
+++ b/terragrunt/org_account/main/guardduty.tf
@@ -99,7 +99,7 @@ resource "aws_guardduty_organization_configuration" "config_us_west_2" {
 
 
 module "publishing_bucket" {
-  source = "github.com/cds-snc/terraform-modules?ref=v3.0.2//S3"
+  source = "github.com/cds-snc/terraform-modules//S3?ref=v3.0.2"
 
   providers = {
     aws = aws.log_archive
@@ -124,7 +124,7 @@ module "publishing_bucket" {
 }
 
 module "publishing_log_bucket" {
-  source = "github.com/cds-snc/terraform-modules?ref=v3.0.2//S3_log_bucket"
+  source = "github.com/cds-snc/terraform-modules//S3_log_bucket?ref=v3.0.2"
 
   providers = {
     aws = aws.log_archive

--- a/terragrunt/org_account/main/main.tf
+++ b/terragrunt/org_account/main/main.tf
@@ -1,5 +1,5 @@
 module "password_policy" {
-  source = "github.com/cds-snc/terraform-modules?ref=v3.0.2//aws_goc_password_policy"
+  source = "github.com/cds-snc/terraform-modules//aws_goc_password_policy?ref=v3.0.2"
 }
 
 

--- a/terragrunt/org_account/main/oidc_role.tf
+++ b/terragrunt/org_account/main/oidc_role.tf
@@ -1,5 +1,5 @@
 module "gh_oidc_roles" {
-  source = "github.com/cds-snc/terraform-modules?ref=v4.0.0//gh_oidc_role"
+  source = "github.com/cds-snc/terraform-modules//gh_oidc_role?ref=v4.0.0"
   roles = [
     {
       name      = local.admin_plan_role

--- a/terragrunt/org_account/main/sentinel_forwarders.tf
+++ b/terragrunt/org_account/main/sentinel_forwarders.tf
@@ -4,7 +4,7 @@ module "guardduty_forwarder" {
     aws = aws.log_archive
   }
 
-  source            = "github.com/cds-snc/terraform-modules?ref=v3.0.19//sentinel_forwarder"
+  source            = "github.com/cds-snc/terraform-modules//sentinel_forwarder?ref=v3.0.19"
   function_name     = "sentinel-guard-duty-forwarder"
   billing_tag_value = var.billing_code
 
@@ -30,7 +30,7 @@ module "securityhub_forwarder" {
     aws = aws.log_archive
   }
 
-  source            = "github.com/cds-snc/terraform-modules?ref=v3.0.19//sentinel_forwarder"
+  source            = "github.com/cds-snc/terraform-modules//sentinel_forwarder?ref=v3.0.19"
   function_name     = "sentinel-securityhub-forwarder"
   billing_tag_value = var.billing_code
 

--- a/terragrunt/org_account/roles/OIDC.tf
+++ b/terragrunt/org_account/roles/OIDC.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 module "OIDC_Roles" {
-  source      = "github.com/cds-snc/terraform-modules?ref=v5.0.0//gh_oidc_role"
+  source      = "github.com/cds-snc/terraform-modules//gh_oidc_role?ref=v5.0.0"
   oidc_exists = true
 
   roles = [{


### PR DESCRIPTION
# Summary | Résumé

Changing the terraform source module reference to use the format as documented in the terraform documentation - https://developer.hashicorp.com/terraform/language/modules/sources#modules-in-package-sub-directories.

I am sorry, but I did not update the modules to use the latest version since I did not want to break anything such mission critical. If you think it is safe for me to do so, I am happy to update to the latest version. 
