### PR TITLE
Alert on 35% increases in daily AWS account cost

### DIFF
--- a/terragrunt/org_account/spend_notifier/lambdas/spend_notifier/spend_notifier.js
+++ b/terragrunt/org_account/spend_notifier/lambdas/spend_notifier/spend_notifier.js
@@ -25,7 +25,6 @@ exports.handler = async (event) => {
           accountIncreases[accounts[key]["Name"]] = dailyAccountCost[key]
     }
   });
-  console.log(dailyAccountCost)
   let BU = {}
 
   Object.values(accounts).forEach(account => {
@@ -79,10 +78,9 @@ exports.handler = async (event) => {
       "blocks": blocks
     }
   )
-  console.log(data)
 
   const options = {
-    //hostname: 'sre-bot.cdssandbox.xyz',
+    hostname: 'sre-bot.cdssandbox.xyz',
     port: 443,
     path: `/hook/${hook}`,
     method: 'POST',
@@ -93,7 +91,7 @@ exports.handler = async (event) => {
   }
   const resp = await doRequest(options, data);
   console.log(resp)
-  
+
   const response = {
     statusCode: 200,
     body: JSON.stringify({ success: true }),

--- a/terragrunt/org_account/spend_notifier/lambdas/spend_notifier/spend_notifier.js
+++ b/terragrunt/org_account/spend_notifier/lambdas/spend_notifier/spend_notifier.js
@@ -1,12 +1,10 @@
 const AWS = require('aws-sdk');
-const { get } = require('http');
 const costexplorer = new AWS.CostExplorer({ region: 'us-east-1' });
 const organizations = new AWS.Organizations({ region: 'us-east-1' });
 
 const https = require('https')
 
-//exports.handler = async (event) => {
-  async function test(event) {
+exports.handler = async (event) => {
   console.log(event)
   const hook = event.hook;
   const today = new Date();
@@ -261,5 +259,3 @@ Number.prototype.pad = function (size) {
   while (s.length < (size || 2)) { s = "0" + s; }
   return s;
 }
-
-test("");

--- a/terragrunt/org_account/spend_notifier/lambdas/spend_notifier/spend_notifier.js
+++ b/terragrunt/org_account/spend_notifier/lambdas/spend_notifier/spend_notifier.js
@@ -25,6 +25,7 @@ exports.handler = async (event) => {
           accountIncreases[accounts[key]["Name"]] = dailyAccountCost[key]
     }
   });
+  console.log(dailyAccountCost)
   let BU = {}
 
   Object.values(accounts).forEach(account => {
@@ -62,7 +63,7 @@ exports.handler = async (event) => {
   const costIncreasedAccountsSection= {
         "type": "section",
         "text": 
-          { "type": "mrkdwn", "text": `Accounts *${costIncreasedAccounts}* saw at least *35% increase in cost* yesterday from previous day cost calculations.` },
+          { "type": "mrkdwn", "text": `Account(s) *${costIncreasedAccounts}* saw at least *35% increase in cost* yesterday from previous day cost calculations.` },
     }
 
   blocks.splice(0,0, header)
@@ -78,9 +79,10 @@ exports.handler = async (event) => {
       "blocks": blocks
     }
   )
+  console.log(data)
 
   const options = {
-    hostname: 'sre-bot.cdssandbox.xyz',
+    //hostname: 'sre-bot.cdssandbox.xyz',
     port: 443,
     path: `/hook/${hook}`,
     method: 'POST',

--- a/terragrunt/org_account/spend_notifier/lambdas/spend_notifier/spend_notifier.js
+++ b/terragrunt/org_account/spend_notifier/lambdas/spend_notifier/spend_notifier.js
@@ -1,4 +1,3 @@
-process.env.AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE = '1';
 const AWS = require('aws-sdk');
 const { get } = require('http');
 const costexplorer = new AWS.CostExplorer({ region: 'us-east-1' });
@@ -11,9 +10,11 @@ const https = require('https')
   console.log(event)
   const hook = event.hook;
   const today = new Date();
+
   // call the daily cost function to get daily costs
   const dailyAccountCost = await getDailyAccountCost()
   console.log("Daily account cost", dailyAccountCost)
+
   const accountCost = await getAccountCost()
   console.log("Account cost", accountCost)
   let accounts = await getAccounts()
@@ -25,8 +26,8 @@ const https = require('https')
     } else {
       accounts[key]["Cost"] = 0
     }
-    // if there is a 50% increase in costs for yesterady vs day before, add to accountIncreases
-    if(dailyAccountCost.hasOwnProperty(key) && dailyAccountCost[key] > 50) {
+    // if there is a 35% increase in costs for yesterady vs day before, add to accountIncreases
+    if(dailyAccountCost.hasOwnProperty(key) && dailyAccountCost[key] > 35) {
           accountIncreases[accounts[key]["Name"]] = dailyAccountCost[key]
     }
   });
@@ -78,14 +79,14 @@ const https = require('https')
   const costIncreasedAccountsSection= {
         "type": "section",
         "text": 
-          { "type": "mrkdwn", "text": `Accounts *${costIncreasedAccounts}* saw at least *50% increase in cost* yesterday from previous day cost calculations.` },
+          { "type": "mrkdwn", "text": `Accounts *${costIncreasedAccounts}* saw at least *35% increase in cost* yesterday from previous day cost calculations.` },
     }
 
   blocks.splice(0,0, header)
   blocks.push({ "type": "divider"})
   blocks.push(footer)
 
-  // if there are accounts that have 50% increase in cost, add the section to the message
+  // if there are accounts that have 35% increase in cost, add the section to the message
   if (costIncreasedAccounts.length > 0) {
     blocks.push(costIncreasedAccountsSection);
   }
@@ -96,7 +97,7 @@ const https = require('https')
   )
   console.log(data)
   const options = {
-   // hostname: 'sre-bot.cdssandbox.xyz',
+    hostname: 'sre-bot.cdssandbox.xyz',
     port: 443,
     path: `/hook/${hook}`,
     method: 'POST',

--- a/terragrunt/org_account/spend_notifier/lambdas/spend_notifier/spend_notifier.js
+++ b/terragrunt/org_account/spend_notifier/lambdas/spend_notifier/spend_notifier.js
@@ -55,7 +55,7 @@ exports.handler = async (event) => {
         "type": "section",
         "fields": [{ "type": "mrkdwn", "text": `*${bu[0]}*` }, { "type": "mrkdwn", "text": `$${bu[1].toFixed(2).replace(/\d(?=(\d{3})+\.)/g, '$&,')} USD` }]
     }
-    )).flat();
+    )).flat()
 
   // concatenate accounts that have increases and construct a new blocks section 
   const costIncreasedAccounts= Object.keys(accountIncreases).join(', ').toString()
@@ -78,6 +78,7 @@ exports.handler = async (event) => {
       "blocks": blocks
     }
   )
+
   const options = {
     hostname: 'sre-bot.cdssandbox.xyz',
     port: 443,
@@ -89,6 +90,7 @@ exports.handler = async (event) => {
     }
   }
   const resp = await doRequest(options, data);
+  console.log(resp)
   
   const response = {
     statusCode: 200,

--- a/terragrunt/org_account/spend_notifier/lambdas/spend_notifier/spend_notifier.js
+++ b/terragrunt/org_account/spend_notifier/lambdas/spend_notifier/spend_notifier.js
@@ -5,18 +5,14 @@ const organizations = new AWS.Organizations({ region: 'us-east-1' });
 const https = require('https')
 
 exports.handler = async (event) => {
-  console.log(event)
   const hook = event.hook;
   const today = new Date();
 
   // call the daily cost function to get daily costs
   const dailyAccountCost = await getDailyAccountCost()
-  console.log("Daily account cost", dailyAccountCost)
 
   const accountCost = await getAccountCost()
-  console.log("Account cost", accountCost)
   let accounts = await getAccounts()
-  console.log("Accounts are", accounts)
   let accountIncreases = {}
   Object.keys(accounts).forEach(key => {
     if(accountCost.hasOwnProperty(key)){
@@ -29,7 +25,6 @@ exports.handler = async (event) => {
           accountIncreases[accounts[key]["Name"]] = dailyAccountCost[key]
     }
   });
-  console.log("Account increases", accountIncreases)
   let BU = {}
 
   Object.values(accounts).forEach(account => {
@@ -39,17 +34,7 @@ exports.handler = async (event) => {
       BU[account["BU"]] = account["Cost"]
     }
   })
-
-  Object.values(accounts).forEach(account => {
-    if (BU.hasOwnProperty(account["BU"])) {
-      BU[account["BU"]] = BU[account["BU"]] + account["Cost"]
-    } else {
-      BU[account["BU"]] = account["Cost"]
-    }
-  })
   const totalCost = Object.values(BU).reduce((a, b) => a + b, 0)
-  console.log("Business unit", BU)
-  console.log("Total cost", totalCost)
 
   const header = {
           "type": "header",
@@ -93,7 +78,6 @@ exports.handler = async (event) => {
       "blocks": blocks
     }
   )
-  console.log(data)
   const options = {
     hostname: 'sre-bot.cdssandbox.xyz',
     port: 443,
@@ -105,8 +89,7 @@ exports.handler = async (event) => {
     }
   }
   const resp = await doRequest(options, data);
-  console.log(resp)
-
+  
   const response = {
     statusCode: 200,
     body: JSON.stringify({ success: true }),


### PR DESCRIPTION
# Summary | Résumé

Modified the spend notifier function to detect increases in AWS cost increase of 35% from previous days. The new code loops through the costs from yesterday and the day before and calculates the percentage difference between those 2 days. If yesterday saw a 35% plus increase from the day before yesterday, then the message with the accounts affected is added to the alert notification sent in Slack.  This is what the message will look like:

<img width="597" alt="Screenshot 2023-08-21 at 10 27 14 AM" src="https://github.com/cds-snc/cds-aws-lz/assets/85905333/28d4ba17-31b3-469d-84c0-b29fc850ef53">
