### PR TITLE
Changing notification based on scratch accounts

### DIFF
--- a/terragrunt/org_account/spend_notifier/lambdas/spend_notifier/spend_notifier.js
+++ b/terragrunt/org_account/spend_notifier/lambdas/spend_notifier/spend_notifier.js
@@ -107,7 +107,7 @@ exports.handler = async (event) => {
       "blocks": blocks
     }
   )
-  console.log(data)
+  
   const options = {
     hostname: 'sre-bot.cdssandbox.xyz',
     port: 443,


### PR DESCRIPTION
# Summary | Résumé

The following changes were made to the spend notifier lambda function:

- If the account is not a scratch account, only then the daily account increases will be taken into consideration. 
- If a scratch account exceeds $500 in a day and it did not do so the previous day, then it will get reported.

The new message will look something like this:

<img width="639" alt="Screenshot 2023-08-22 at 3 38 03 PM" src="https://github.com/cds-snc/cds-aws-lz/assets/85905333/99b0feb1-e78f-4f34-b3da-ecfe47fc150f">
