### PR TITLE
Changing scratch account checking

### DIFF
--- a/terragrunt/org_account/spend_notifier/lambdas/spend_notifier/spend_notifier.js
+++ b/terragrunt/org_account/spend_notifier/lambdas/spend_notifier/spend_notifier.js
@@ -30,7 +30,7 @@ exports.handler = async (event) => {
     }
 
     // if the account is not a scratch account and there is a 35% increase in costs for yesterday vs day before, add to accountIncreases
-    if(dailyAccountCost.hasOwnProperty(key) && dailyAccountCost[key] > 35 && !accounts[key]["Name"].toLowerCase().includes("scratch")) {
+    if(dailyAccountCost.hasOwnProperty(key) && dailyAccountCost[key] > 35 && !accounts[key]["isScratch"]) {
           accountIncreases[accounts[key]["Name"]] = dailyAccountCost[key]
     }
 


### PR DESCRIPTION
# Summary | Résumé

Changing the is scratch account checking to be more efficient and properly done since we already store whether the account is scratch or not. 