### PR TITLE
feat: add SRE Security Hub automation rule role

### DIFF
--- a/terragrunt/log_archive/sre_bot/OIDC.tf
+++ b/terragrunt/log_archive/sre_bot/OIDC.tf
@@ -2,11 +2,18 @@ module "OIDC_Roles" {
   source      = "github.com/cds-snc/terraform-modules//gh_oidc_role?ref=v5.0.0"
   oidc_exists = true
 
-  roles = [{
-    name      = local.sre_vulnerability_report_oidc_role
-    repo_name = "site-reliability-engineering"
-    claim     = "ref:refs/heads/main"
-  }]
+  roles = [
+    {
+      name      = local.sre_vulnerability_report_oidc_role
+      repo_name = "site-reliability-engineering"
+      claim     = "ref:refs/heads/main"
+    },
+    {
+      name      = local.sre_sechub_automation_rules_oidc_role
+      repo_name = "site-reliability-engineering"
+      claim     = "ref:refs/heads/main"
+    }
+  ]
 
   billing_tag_value = var.billing_code
 }

--- a/terragrunt/log_archive/sre_bot/locals.tf
+++ b/terragrunt/log_archive/sre_bot/locals.tf
@@ -3,5 +3,6 @@ locals {
     CostCentre = var.billing_code
     Terraform  = "true"
   }
-  sre_vulnerability_report_oidc_role = "sre_vulnerability_report_github_action"
+  sre_sechub_automation_rules_oidc_role = "sre_sechub_automation_rules_github_action"
+  sre_vulnerability_report_oidc_role    = "sre_vulnerability_report_github_action"
 }

--- a/terragrunt/log_archive/sre_bot/sre_sechub_automation_rules.tf
+++ b/terragrunt/log_archive/sre_bot/sre_sechub_automation_rules.tf
@@ -31,4 +31,7 @@ resource "aws_iam_policy" "sre_sechub_automation_rules" {
 resource "aws_iam_role_policy_attachment" "sre_sechub_automation_rules" {
   role       = aws_iam_role.sre_sechub_automation_rules_oidc_role.name
   policy_arn = aws_iam_policy.sre_sechub_automation_rules.arn
+  depends_on = [
+    module.OIDC_Roles
+  ]
 }

--- a/terragrunt/log_archive/sre_bot/sre_sechub_automation_rules.tf
+++ b/terragrunt/log_archive/sre_bot/sre_sechub_automation_rules.tf
@@ -29,7 +29,7 @@ resource "aws_iam_policy" "sre_sechub_automation_rules" {
 }
 
 resource "aws_iam_role_policy_attachment" "sre_sechub_automation_rules" {
-  role       = aws_iam_role.sre_sechub_automation_rules_oidc_role.name
+  role       = local.sre_sechub_automation_rules_oidc_role
   policy_arn = aws_iam_policy.sre_sechub_automation_rules.arn
   depends_on = [
     module.OIDC_Roles

--- a/terragrunt/log_archive/sre_bot/sre_sechub_automation_rules.tf
+++ b/terragrunt/log_archive/sre_bot/sre_sechub_automation_rules.tf
@@ -1,0 +1,34 @@
+#
+# Role used by the cds-snc/site-reliability-engineering/tools/aws-security-hub-automation-rules to 
+# manage Security Hub automation rules.
+#
+# It will be assumed by the GitHub Actions workflow.
+#
+
+data "aws_iam_policy_document" "sre_sechub_automation_rules" {
+  version = "2012-10-17"
+
+  statement {
+    sid    = "ManageSecurityHubAutomationRules"
+    effect = "Allow"
+    actions = [
+      "securityhub:BatchDeleteAutomationRules",
+      "securityhub:BatchGetAutomationRules",
+      "securityhub:CreateAutomationRule",
+      "securityhub:ListAutomationRules"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "sre_sechub_automation_rules" {
+  name   = "sre_sechub_automation_rules"
+  policy = data.aws_iam_policy_document.sre_sechub_automation_rules.json
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "sre_sechub_automation_rules" {
+  role       = aws_iam_role.sre_sechub_automation_rules_oidc_role.name
+  policy_arn = aws_iam_policy.sre_sechub_automation_rules.arn
+}


### PR DESCRIPTION
# Summary
Add an OIDC rule that can be used by the SRE repo by the [`tools/aws-security-automation-rules`](https://github.com/cds-snc/site-reliability-engineering/blob/main/tools/aws-security-hub-automation-rules/README.md) script to manage Security Hub automation rules.

# Related
- https://github.com/cds-snc/site-reliability-engineering/pull/1020
- https://github.com/cds-snc/platform-core-services/issues/471