### PR TITLE
fix: member accounts inherit Security Hub settings

### DIFF
--- a/terragrunt/modules/existing_security_hub_member/main.tf
+++ b/terragrunt/modules/existing_security_hub_member/main.tf
@@ -3,8 +3,7 @@
 resource "aws_securityhub_account" "this" {
   provider = aws.member
 
-  auto_enable_controls      = true
-  control_finding_generator = "SECURITY_CONTROL"  
+  auto_enable_controls = true
 }
 
 data "aws_caller_identity" "member" {


### PR DESCRIPTION
# Summary
Update the member account Security Hub resource as the settings are inherited from the Security Hub administrator account.

# Related
- https://github.com/cds-snc/platform-core-services/issues/471