### PR TITLE
feat: add Control Tower log group metric filters

### DIFF
--- a/terragrunt/org_account/organization/cloudwatch.tf
+++ b/terragrunt/org_account/organization/cloudwatch.tf
@@ -1,0 +1,80 @@
+#
+# CloudWatch metric filters to address Security Hub findings
+#
+locals {
+  control_tower_metric_filters = [
+    {
+      name    = "use_of_root_account"
+      pattern = "{$.userIdentity.type=\"Root\" && $.userIdentity.invokedBy NOT EXISTS && $.eventType !=\"AwsServiceEvent\"}"
+    },
+    {
+      name    = "unauthorized_api_call"
+      pattern = "{($.errorCode=\"*UnauthorizedOperation\") || ($.errorCode=\"AccessDenied*\")}"
+    },
+    {
+      name    = "console_sign_in_without_mfa"
+      pattern = "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") && ($.userIdentity.type = \"IAMUser\") && ($.responseElements.ConsoleLogin = \"Success\") }"
+    },
+    {
+      name    = "iam_policy_change"
+      pattern = "{($.eventSource=iam.amazonaws.com) && (($.eventName=DeleteGroupPolicy) || ($.eventName=DeleteRolePolicy) || ($.eventName=DeleteUserPolicy) || ($.eventName=PutGroupPolicy) || ($.eventName=PutRolePolicy) || ($.eventName=PutUserPolicy) || ($.eventName=CreatePolicy) || ($.eventName=DeletePolicy) || ($.eventName=CreatePolicyVersion) || ($.eventName=DeletePolicyVersion) || ($.eventName=AttachRolePolicy) || ($.eventName=DetachRolePolicy) || ($.eventName=AttachUserPolicy) || ($.eventName=DetachUserPolicy) || ($.eventName=AttachGroupPolicy) || ($.eventName=DetachGroupPolicy))}"
+    },
+    {
+      name    = "cloudtrail_setting_change"
+      pattern = "{($.eventName=CreateTrail) || ($.eventName=UpdateTrail) || ($.eventName=DeleteTrail) || ($.eventName=StartLogging) || ($.eventName=StopLogging)}"
+    },
+    {
+      name    = "console_sign_in_failure"
+      pattern = "{($.eventName=ConsoleLogin) && ($.errorMessage=\"Failed authentication\")}"
+    },
+    {
+      name    = "kms_scheduled_delete"
+      pattern = "{($.eventSource=kms.amazonaws.com) && (($.eventName=DisableKey) || ($.eventName=ScheduleKeyDeletion))}"
+    },
+    {
+      name    = "s3_bucket_policy_change"
+      pattern = "{($.eventSource=s3.amazonaws.com) && (($.eventName=PutBucketAcl) || ($.eventName=PutBucketPolicy) || ($.eventName=PutBucketCors) || ($.eventName=PutBucketLifecycle) || ($.eventName=PutBucketReplication) || ($.eventName=DeleteBucketPolicy) || ($.eventName=DeleteBucketCors) || ($.eventName=DeleteBucketLifecycle) || ($.eventName=DeleteBucketReplication))}"
+    },
+    {
+      name    = "config_settings_change"
+      pattern = "{($.eventSource=config.amazonaws.com) && (($.eventName=StopConfigurationRecorder) || ($.eventName=DeleteDeliveryChannel) || ($.eventName=PutDeliveryChannel) || ($.eventName=PutConfigurationRecorder))}"
+    },
+    {
+      name    = "security_group_change"
+      pattern = "{($.eventName=AuthorizeSecurityGroupIngress) || ($.eventName=AuthorizeSecurityGroupEgress) || ($.eventName=RevokeSecurityGroupIngress) || ($.eventName=RevokeSecurityGroupEgress) || ($.eventName=CreateSecurityGroup) || ($.eventName=DeleteSecurityGroup)}"
+    },
+    {
+      name    = "nacl_change"
+      pattern = "{($.eventName=CreateNetworkAcl) || ($.eventName=CreateNetworkAclEntry) || ($.eventName=DeleteNetworkAcl) || ($.eventName=DeleteNetworkAclEntry) || ($.eventName=ReplaceNetworkAclEntry) || ($.eventName=ReplaceNetworkAclAssociation)}"
+    },
+    {
+      name    = "network_gateway_change"
+      pattern = "{($.eventName=CreateCustomerGateway) || ($.eventName=DeleteCustomerGateway) || ($.eventName=AttachInternetGateway) || ($.eventName=CreateInternetGateway) || ($.eventName=DeleteInternetGateway) || ($.eventName=DetachInternetGateway)}"
+    },
+    {
+      name    = "vpc_route_table_change"
+      pattern = "{($.eventSource=ec2.amazonaws.com) && (($.eventName=CreateRoute) || ($.eventName=CreateRouteTable) || ($.eventName=ReplaceRoute) || ($.eventName=ReplaceRouteTableAssociation) || ($.eventName=DeleteRouteTable) || ($.eventName=DeleteRoute) || ($.eventName=DisassociateRouteTable))}"
+    },
+    {
+      name    = "vpc_change"
+      pattern = "{($.eventName=CreateVpc) || ($.eventName=DeleteVpc) || ($.eventName=ModifyVpcAttribute) || ($.eventName=AcceptVpcPeeringConnection) || ($.eventName=CreateVpcPeeringConnection) || ($.eventName=DeleteVpcPeeringConnection) || ($.eventName=RejectVpcPeeringConnection) || ($.eventName=AttachClassicLinkVpc) || ($.eventName=DetachClassicLinkVpc) || ($.eventName=DisableVpcClassicLink) || ($.eventName=EnableVpcClassicLink)}"
+    },
+  ]
+}
+
+resource "aws_cloudwatch_log_metric_filter" "control_tower_metric_filter" {
+  for_each = {
+    for filter in local.control_tower_metric_filters : filter.name => filter
+  }
+
+  name           = each.value.name
+  pattern        = each.value.pattern
+  log_group_name = "aws-controltower/CloudTrailLogs"
+
+  metric_transformation {
+    name          = each.value.name
+    namespace     = "LogMetrics"
+    value         = "1"
+    default_value = "0"
+  }
+}


### PR DESCRIPTION
# Summary
Add CloudWatch metric filters to the Control Tower log group. These are the first step towards addressing the Security Hub findings that are failing because they don't exist.

Once the filters have been created, we can determine which can have alarms created and which would cause too much noise.

# Related
- https://github.com/cds-snc/platform-core-services/issues/471
- **[Security Hub > Amazon CloudWatch controls](https://docs.aws.amazon.com/securityhub/latest/userguide/cloudwatch-controls.html)**