### PR TITLE
Changing the log group so that we can receive logging events

### DIFF
--- a/terragrunt/org_account/spend_notifier/iam.tf
+++ b/terragrunt/org_account/spend_notifier/iam.tf
@@ -33,7 +33,7 @@ data "aws_iam_policy_document" "spend_notifier" {
       "logs:PutLogEvents"
     ]
     resources = [
-      "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/daily-spend-monitor:*"
+      "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/spend_notifier:*"
     ]
 
   }


### PR DESCRIPTION

# Summary | Résumé

The cloudspend lambda function was not referencing the right log group and as a result, we were not getting logs. 