### PR TITLE
Fixing error that exists on the second of the month

### DIFF
--- a/terragrunt/org_account/spend_notifier/lambdas/spend_notifier/spend_notifier.js
+++ b/terragrunt/org_account/spend_notifier/lambdas/spend_notifier/spend_notifier.js
@@ -192,7 +192,7 @@ async function getScratchAccountsExceedingThreshold() {
   const yesterday = new Date(today.setDate(today.getDate() - 1)).toISOString().split("T")[0];
 
   // do this calculation only if yesterday is greater than or equal to the first day of the month. This is needed since we go back 2 days to calculate the difference in cost.
-  if (yesterday >= firstDayOfMonth) {
+  if (yesterday > firstDayOfMonth) {
     // construct params for cost explorer
     const paramsYesterday = {
       Granularity: "MONTHLY",


### PR DESCRIPTION
# Summary | Résumé

Fixes an error that always exists on the second of the month where the lambda function fails due to the following error message " "errorType": "ValidationException","errorMessage": "Start date (and hour) should be before end date (and hour)" from the Cost explorer API. 