### PR TITLE
fix: disable billing tag bucket ACL

### DIFF
--- a/terragrunt/org_account/billing_extract_tags/s3.tf
+++ b/terragrunt/org_account/billing_extract_tags/s3.tf
@@ -14,8 +14,9 @@ import {
 }
 
 module "billing_extract_tags" {
-  source      = "github.com/cds-snc/terraform-modules//S3?ref=v9.2.4"
+  source      = "github.com/cds-snc/terraform-modules//S3?ref=v9.2.5"
   bucket_name = "5bf89a78-1503-4e02-9621-3ac658f558fb"
+  acl         = null
 
   versioning = {
     enabled = true


### PR DESCRIPTION
# Summary
Update the target bucket for the billing tag extract data to disable its ACL.  This is recommended by AWS when a bucket policy has been created to control access.