### PR TITLE
fix: add newlines back to billing tag JSON export

### DIFF
--- a/terragrunt/org_account/billing_extract_tags/lambdas/billing_extract_tags/main.py
+++ b/terragrunt/org_account/billing_extract_tags/lambdas/billing_extract_tags/main.py
@@ -15,7 +15,7 @@ s3 = boto3.client("s3")
 TARGET_BUCKET = os.getenv("TARGET_BUCKET")
 
 
-def lambda_handler(event, context):
+def handler(event, context):
     """
     Get the tags for all accounts in the organization and save them to an s3 bucket
     """
@@ -62,8 +62,8 @@ def lambda_handler(event, context):
     # .write json to string and add a newline between each record
     logging.info("Writing account tags to json")
     accounts = json.dumps(accounts, default=str)
-    # accounts = accounts.replace('},', '},\n')
-    # accounts = accounts.replace('[{', '[\n{')
+    accounts = accounts.replace("}, ", "},\n")
+    accounts = accounts.replace("[{", "[\n{")
     logging.info(f"Accounts: {accounts}")
 
     # save accounts to an s3 bucket

--- a/terragrunt/org_account/billing_extract_tags/s3.tf
+++ b/terragrunt/org_account/billing_extract_tags/s3.tf
@@ -1,18 +1,3 @@
-import {
-  to = module.billing_extract_tags.aws_s3_bucket.this
-  id = "5bf89a78-1503-4e02-9621-3ac658f558fb"
-}
-
-import {
-  to = module.billing_extract_tags.aws_s3_bucket_public_access_block.this
-  id = "5bf89a78-1503-4e02-9621-3ac658f558fb"
-}
-
-import {
-  to = aws_s3_bucket_policy.billing_extract_tags
-  id = "5bf89a78-1503-4e02-9621-3ac658f558fb"
-}
-
 module "billing_extract_tags" {
   source      = "github.com/cds-snc/terraform-modules//S3?ref=v9.2.5"
   bucket_name = "5bf89a78-1503-4e02-9621-3ac658f558fb"


### PR DESCRIPTION
# Summary
Update the Lambda function to add newlines between each billing tag export line.  These are required by AWS Glue for parsing the JSON data.

Remove the `import` blocks as the resources have new been brought into the TF state.