### PR TITLE
fix: attach univ guardrails to Security OU

### DIFF
--- a/terragrunt/org_account/organization/organizations.tf
+++ b/terragrunt/org_account/organization/organizations.tf
@@ -64,6 +64,10 @@ resource "aws_organizations_organizational_unit" "Security" {
   parent_id = local.root
 }
 
+resource "aws_organizations_policy_attachment" "Security-cds_snc_universal_guardrails" {
+  policy_id = aws_organizations_policy.cds_snc_universal_guardrails.id
+  target_id = aws_organizations_organizational_unit.Security.id
+}
 
 resource "aws_organizations_organizational_unit" "SRETools" {
   name      = "SRETools"


### PR DESCRIPTION
# Summary | Résumé

Attach the universal guardrails to the Security OU