### PR TITLE
SCP to deny everything in case of an emergency

### DIFF
--- a/terragrunt/org_account/organization/scp.tf
+++ b/terragrunt/org_account/organization/scp.tf
@@ -157,3 +157,21 @@ resource "aws_organizations_policy" "cds_snc_universal_guardrails" {
   type    = "SERVICE_CONTROL_POLICY"
   content = data.aws_iam_policy_document.cds_snc_universal_guardrails.json
 }
+
+data "aws_iam_policy_document" "qurantine_deny_all_policy" {
+  statement {
+    sid    = "DenyAllActions"
+    effect = "Deny"
+
+    actions = ["*"]
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_organizations_policy" "qurantine_deny_all_policy" {
+  name    = "Qurantine account and Deny All Policy"
+  type    = "SERVICE_CONTROL_POLICY"
+  content = data.aws_iam_policy_document.qurantine_deny_all_policy.json
+}


### PR DESCRIPTION
# Summary | Résumé

SCP that we can attach to a quarantine or dumpster fire OU that would allow us to deny all actions on compromised accounts.