### PR TITLE
feat: setup OIDC role for the SRE Audit tool

### DIFF
--- a/terragrunt/org_account/roles/OIDC.tf
+++ b/terragrunt/org_account/roles/OIDC.tf
@@ -86,32 +86,3 @@ resource "aws_iam_role_policy_attachment" "attach_org_allow_policy_toggle" {
   ]
 
 }
-
-data "aws_iam_policy_document" "assume_sre_identity_audit" {
-  statement {
-    sid = "AssumeSREIdentityAuditRoles"
-
-    actions = [
-      "sts:AssumeRole",
-    ]
-
-    resources = [
-      aws_iam_role.sre_identity_audit.arn,
-      "arn:aws:iam::${var.account_id}:role/sre_identity_audit" # org_account
-    ]
-  }
-}
-
-resource "aws_iam_policy" "assume_sre_identity_audit" {
-  name   = local.sre_identity_audit_oidc_role
-  policy = data.aws_iam_policy_document.assume_sre_identity_audit.json
-
-  tags = local.common_tags
-}
-
-resource "aws_iam_role_policy_attachment" "assume_sre_identity_audit" {
-  role       = local.sre_identity_audit_oidc_role
-  policy_arn = aws_iam_policy.assume_sre_identity_audit.arn
-
-  depends_on = [module.OIDC_Roles]
-}

--- a/terragrunt/org_account/roles/OIDC.tf
+++ b/terragrunt/org_account/roles/OIDC.tf
@@ -97,7 +97,7 @@ data "aws_iam_policy_document" "assume_sre_identity_audit" {
 
     resources = [
       aws_iam_role.sre_identity_audit.arn,
-      "arn:aws:iam::659087519042:role/sre_identity_audit" # org_account
+      "arn:aws:iam::${var.account_id}:role/sre_identity_audit" # org_account
     ]
   }
 }

--- a/terragrunt/org_account/roles/OIDC.tf
+++ b/terragrunt/org_account/roles/OIDC.tf
@@ -74,7 +74,7 @@ resource "aws_iam_policy" "org_allow_policy_toggle" {
   name   = local.org_allow_policy_toggle
   policy = data.aws_iam_policy_document.org_allow_policy_toggle.json
 
-    tags = local.common_tags
+  tags = local.common_tags
 
 }
 

--- a/terragrunt/org_account/roles/OIDC.tf
+++ b/terragrunt/org_account/roles/OIDC.tf
@@ -97,7 +97,7 @@ data "aws_iam_policy_document" "assume_sre_identity_audit" {
 
     resources = [
       aws_iam_role.sre_identity_audit.arn,
-      "arn:aws:iam::${var.account_id}:role/sre_identity_audit" # org_account
+      "arn:aws:iam::659087519042:role/sre_identity_audit" # org_account
     ]
   }
 }

--- a/terragrunt/org_account/roles/OIDC.tf
+++ b/terragrunt/org_account/roles/OIDC.tf
@@ -46,6 +46,8 @@ data "aws_iam_policy_document" "org_account_list_in_sandbox" {
 resource "aws_iam_policy" "org_account_list_in_sandbox" {
   name   = local.org_account_list_name
   policy = data.aws_iam_policy_document.org_account_list_in_sandbox.json
+
+  tags = local.common_tags
 }
 
 # Attach the policy document to the role loca.org_account_list_name
@@ -77,6 +79,8 @@ resource "aws_iam_policy" "org_allow_policy_toggle" {
   name   = local.org_allow_policy_toggle
   policy = data.aws_iam_policy_document.org_allow_policy_toggle.json
 
+    tags = local.common_tags
+
 }
 
 resource "aws_iam_role_policy_attachment" "attach_org_allow_policy_toggle" {
@@ -106,4 +110,6 @@ data "aws_iam_policy_document" "assume_sre_identity_audit" {
 resource "aws_iam_policy" "assume_sre_identity_audit" {
   name   = local.sre_identity_audit_oidc_role
   policy = data.aws_iam_policy_document.assume_sre_identity_audit.json
+
+  tags = local.common_tags
 }

--- a/terragrunt/org_account/roles/OIDC.tf
+++ b/terragrunt/org_account/roles/OIDC.tf
@@ -1,8 +1,3 @@
-locals {
-  org_account_list_name        = "listAccountsInSandboxOUForNuke"
-  org_allow_policy_toggle      = "ghActionAllowPolicyToggle"
-  sre_identity_audit_oidc_role = "sre_identity_audit_oidc_role"
-}
 
 module "OIDC_Roles" {
   source      = "github.com/cds-snc/terraform-modules//gh_oidc_role?ref=v5.0.0"
@@ -112,4 +107,9 @@ resource "aws_iam_policy" "assume_sre_identity_audit" {
   policy = data.aws_iam_policy_document.assume_sre_identity_audit.json
 
   tags = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "assume_sre_identity_audit" {
+  role       = local.sre_identity_audit_oidc_role
+  policy_arn = aws_iam_policy.assume_sre_identity_audit.arn
 }

--- a/terragrunt/org_account/roles/OIDC.tf
+++ b/terragrunt/org_account/roles/OIDC.tf
@@ -112,4 +112,6 @@ resource "aws_iam_policy" "assume_sre_identity_audit" {
 resource "aws_iam_role_policy_attachment" "assume_sre_identity_audit" {
   role       = local.sre_identity_audit_oidc_role
   policy_arn = aws_iam_policy.assume_sre_identity_audit.arn
+
+  depends_on = [module.OIDC_Roles]
 }

--- a/terragrunt/org_account/roles/OIDC.tf
+++ b/terragrunt/org_account/roles/OIDC.tf
@@ -41,8 +41,6 @@ data "aws_iam_policy_document" "org_account_list_in_sandbox" {
 resource "aws_iam_policy" "org_account_list_in_sandbox" {
   name   = local.org_account_list_name
   policy = data.aws_iam_policy_document.org_account_list_in_sandbox.json
-
-  tags = local.common_tags
 }
 
 # Attach the policy document to the role loca.org_account_list_name
@@ -73,8 +71,6 @@ data "aws_iam_policy_document" "org_allow_policy_toggle" {
 resource "aws_iam_policy" "org_allow_policy_toggle" {
   name   = local.org_allow_policy_toggle
   policy = data.aws_iam_policy_document.org_allow_policy_toggle.json
-
-  tags = local.common_tags
 
 }
 

--- a/terragrunt/org_account/roles/inputs.tf
+++ b/terragrunt/org_account/roles/inputs.tf
@@ -13,8 +13,3 @@ variable "region" {
   type        = string
   description = "(Required) The region for the account"
 }
-
-variable "billing_code" {
-  type        = string
-  description = "(Required) The billing code for the account"
-}

--- a/terragrunt/org_account/roles/inputs.tf
+++ b/terragrunt/org_account/roles/inputs.tf
@@ -4,12 +4,3 @@ variable "admin_sso_role_arn" {
   sensitive   = true
 }
 
-variable "account_id" {
-  type        = string
-  description = "(Required) The account ID for the account"
-}
-
-variable "region" {
-  type        = string
-  description = "(Required) The region for the account"
-}

--- a/terragrunt/org_account/roles/inputs.tf
+++ b/terragrunt/org_account/roles/inputs.tf
@@ -3,3 +3,18 @@ variable "admin_sso_role_arn" {
   description = "(Required) The ARN for the admin SSO role"
   sensitive   = true
 }
+
+variable "account_id" {
+  type        = string
+  description = "(Required) The account ID for the account"
+}
+
+variable "region" {
+  type        = string
+  description = "(Required) The region for the account"
+}
+
+variable "billing_code" {
+  type        = string
+  description = "(Required) The billing code for the account"
+}

--- a/terragrunt/org_account/roles/locals.tf
+++ b/terragrunt/org_account/roles/locals.tf
@@ -3,4 +3,7 @@ locals {
     CostCentre = var.billing_code
     Terraform  = "true"
   }
+  org_account_list_name        = "listAccountsInSandboxOUForNuke"
+  org_allow_policy_toggle      = "ghActionAllowPolicyToggle"
+  sre_identity_audit_oidc_role = "sre_identity_audit_oidc_role"
 }

--- a/terragrunt/org_account/roles/sre_identity_audit.tf
+++ b/terragrunt/org_account/roles/sre_identity_audit.tf
@@ -35,7 +35,7 @@ data "aws_iam_policy_document" "sre_identity_audit" {
       "identitystore:ListGroups",
       "identitystore:ListGroupMemberships"
     ]
-    resources = ["arn:aws:identitystore:${var.region}:${var.account_id}:identitystore/*"]
+    resources = ["*"]
   }
 
   statement {
@@ -50,7 +50,7 @@ data "aws_iam_policy_document" "sre_identity_audit" {
       "sso:ListAccountsForProvisionedPermissionSet"
 
     ]
-    resources = ["arn:aws:sso:::instance/*"]
+    resources = ["*"]
   }
 
   statement {
@@ -59,7 +59,7 @@ data "aws_iam_policy_document" "sre_identity_audit" {
     actions = [
       "organizations:ListAccounts",
     ]
-    resources = ["arn:aws:organizations::${var.account_id}:account/*"]
+    resources = ["*"]
   }
 }
 

--- a/terragrunt/org_account/roles/sre_identity_audit.tf
+++ b/terragrunt/org_account/roles/sre_identity_audit.tf
@@ -1,11 +1,10 @@
 #
-# Role used by the cds-snc/site-reliability-engineering/tools/aws-identity-center-audit to read the identitystore, sso-admin and organizations service configurations.
+# Role used by the cds-snc/site-reliability-engineering/tools/aws-identity-center-audit to read the identitystore, sso and organizations service configurations.
 #
 # It will be assumed by the GitHub Actions workflow.
 #
 data "aws_iam_policy_document" "sre_identity_audit_assume" {
   statement {
-    effect = "Allow"
     sid     = "AssumeRole"
     actions = ["sts:AssumeRole"]
     principals {
@@ -33,7 +32,7 @@ data "aws_iam_policy_document" "sre_identity_audit" {
     actions = [
       "identitystore:ListUsers",
       "identitystore:ListGroups",
-      "identitystore:ListGroupMemberships",
+      "identitystore:ListGroupMemberships"
     ]
     resources = ["arn:aws:identitystore:${var.region}:${var.account_id}:identitystore/*"]
   }
@@ -42,12 +41,13 @@ data "aws_iam_policy_document" "sre_identity_audit" {
     sid    = "ReadSSOAdmin"
     effect = "Allow"
     actions = [
-      "sso-admin:DescribeInstance",
-      "sso-admin:DescribePermissionSet",
-      "sso-admin:ListPermissionSets",
-      "sso-admin:ListPermissionSetsProvisionedToAccount",
-      "sso-admin:ListAccountAssignments",
-      "sso-admin:ListAccountsForProvisionedPermissionSet",
+      "sso:DescribeInstance",
+      "sso:DescribePermissionSet",
+      "sso:ListPermissionSets",
+      "sso:ListPermissionSetsProvisionedToAccount",
+      "sso:ListAccountAssignments",
+      "sso:ListAccountsForProvisionedPermissionSet"
+
     ]
     resources = ["arn:aws:sso:::instance/ssoins-*"]
   }

--- a/terragrunt/org_account/roles/sre_identity_audit.tf
+++ b/terragrunt/org_account/roles/sre_identity_audit.tf
@@ -13,7 +13,6 @@ data "aws_iam_policy_document" "sre_identity_audit_assume" {
         "arn:aws:iam::${var.account_id}:role/${local.sre_identity_audit_oidc_role}"
       ]
     }
-    effect = "Allow"
   }
 }
 
@@ -60,4 +59,16 @@ data "aws_iam_policy_document" "sre_identity_audit" {
     ]
     resources = ["arn:aws:organizations::${var.account_id}:account/*"]
   }
+}
+
+resource "aws_iam_policy" "sre_identity_audit" {
+  name   = "sre_identity_audit"
+  policy = data.aws_iam_policy_document.sre_identity_audit.json
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "sre_identity_audit" {
+  role       = aws_iam_role.sre_identity_audit.name
+  policy_arn = aws_iam_policy.sre_identity_audit.arn
 }

--- a/terragrunt/org_account/roles/sre_identity_audit.tf
+++ b/terragrunt/org_account/roles/sre_identity_audit.tf
@@ -1,0 +1,62 @@
+#
+# Role used by the cds-snc/site-reliability-engineering/tools/aws-identity-center-audit to read the identitystore, sso-admin and organizations service configurations.
+#
+# It will be assumed by the GitHub Actions workflow.
+#
+data "aws_iam_policy_document" "sre_identity_audit_assume" {
+  statement {
+    sid     = "AssumeRole"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${var.account_id}:role/${local.sre_identity_audit_oidc_role}"
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role" "sre_identity_audit" {
+  name               = "sre_identity_audit"
+  assume_role_policy = data.aws_iam_policy_document.sre_identity_audit_assume.json
+
+  tags = local.common_tags
+}
+
+data "aws_iam_policy_document" "sre_identity_audit" {
+  version = "2012-10-17"
+
+  statement {
+    sid    = "ReadIdentityStore"
+    effect = "Allow"
+    actions = [
+      "identitystore:ListUsers",
+      "identitystore:ListGroups",
+      "identitystore:ListGroupMemberships",
+    ]
+    resources = ["arn:aws:identitystore:${var.region}:${var.account_id}:identitystore/*"]
+  }
+
+  statement {
+    sid    = "ReadSSOAdmin"
+    effect = "Allow"
+    actions = [
+      "sso-admin:DescribeInstance",
+      "sso-admin:DescribePermissionSet",
+      "sso-admin:ListPermissionSets",
+      "sso-admin:ListPermissionSetsProvisionedToAccount",
+      "sso-admin:ListAccountAssignments",
+      "sso-admin:ListAccountsForProvisionedPermissionSet",
+    ]
+    resources = ["arn:aws:sso:::instance/ssoins-*"]
+  }
+
+  statement {
+    sid    = "ReadOrganizations"
+    effect = "Allow"
+    actions = [
+      "organizations:ListAccounts",
+    ]
+    resources = ["arn:aws:organizations::${var.account_id}:account/*"]
+  }
+}

--- a/terragrunt/org_account/roles/sre_identity_audit.tf
+++ b/terragrunt/org_account/roles/sre_identity_audit.tf
@@ -10,7 +10,7 @@ data "aws_iam_policy_document" "sre_identity_audit_assume" {
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::${var.account_id}:role/${local.sre_identity_audit_oidc_role}"
+        "arn:aws:iam::659087519042:role/${local.sre_identity_audit_oidc_role}"
       ]
     }
   }

--- a/terragrunt/org_account/roles/sre_identity_audit.tf
+++ b/terragrunt/org_account/roles/sre_identity_audit.tf
@@ -5,12 +5,13 @@
 #
 data "aws_iam_policy_document" "sre_identity_audit_assume" {
   statement {
+    effect = "Allow"
     sid     = "AssumeRole"
     actions = ["sts:AssumeRole"]
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::659087519042:role/${local.sre_identity_audit_oidc_role}"
+        "arn:aws:iam::${var.account_id}:role/${local.sre_identity_audit_oidc_role}"
       ]
     }
   }

--- a/terragrunt/org_account/roles/sre_identity_audit.tf
+++ b/terragrunt/org_account/roles/sre_identity_audit.tf
@@ -7,6 +7,7 @@ data "aws_iam_policy_document" "sre_identity_audit_assume" {
   statement {
     sid     = "AssumeRole"
     actions = ["sts:AssumeRole"]
+    effect  = "Allow"
     principals {
       type = "AWS"
       identifiers = [
@@ -49,7 +50,7 @@ data "aws_iam_policy_document" "sre_identity_audit" {
       "sso:ListAccountsForProvisionedPermissionSet"
 
     ]
-    resources = ["arn:aws:sso:::instance/ssoins-*"]
+    resources = ["arn:aws:sso:::instance/*"]
   }
 
   statement {

--- a/terragrunt/org_account/roles/sre_identity_audit.tf
+++ b/terragrunt/org_account/roles/sre_identity_audit.tf
@@ -3,27 +3,6 @@
 #
 # It will be assumed by the GitHub Actions workflow.
 #
-data "aws_iam_policy_document" "sre_identity_audit_assume" {
-  statement {
-    sid     = "AssumeRole"
-    actions = ["sts:AssumeRole"]
-    effect  = "Allow"
-    principals {
-      type = "AWS"
-      identifiers = [
-        "arn:aws:iam::${var.account_id}:role/${local.sre_identity_audit_oidc_role}"
-      ]
-    }
-  }
-}
-
-resource "aws_iam_role" "sre_identity_audit" {
-  name               = "sre_identity_audit"
-  assume_role_policy = data.aws_iam_policy_document.sre_identity_audit_assume.json
-
-  tags = local.common_tags
-}
-
 data "aws_iam_policy_document" "sre_identity_audit" {
   version = "2012-10-17"
 
@@ -71,6 +50,9 @@ resource "aws_iam_policy" "sre_identity_audit" {
 }
 
 resource "aws_iam_role_policy_attachment" "sre_identity_audit" {
-  role       = aws_iam_role.sre_identity_audit.name
+  role       = local.sre_identity_audit_oidc_role
   policy_arn = aws_iam_policy.sre_identity_audit.arn
+  depends_on = [ 
+    module.OIDC_Roles
+   ]
 }

--- a/terragrunt/org_account/roles/sre_identity_audit.tf
+++ b/terragrunt/org_account/roles/sre_identity_audit.tf
@@ -13,6 +13,7 @@ data "aws_iam_policy_document" "sre_identity_audit_assume" {
         "arn:aws:iam::${var.account_id}:role/${local.sre_identity_audit_oidc_role}"
       ]
     }
+    effect = "Allow"
   }
 }
 

--- a/terragrunt/org_account/roles/sre_identity_audit.tf
+++ b/terragrunt/org_account/roles/sre_identity_audit.tf
@@ -52,7 +52,7 @@ resource "aws_iam_policy" "sre_identity_audit" {
 resource "aws_iam_role_policy_attachment" "sre_identity_audit" {
   role       = local.sre_identity_audit_oidc_role
   policy_arn = aws_iam_policy.sre_identity_audit.arn
-  depends_on = [ 
+  depends_on = [
     module.OIDC_Roles
-   ]
+  ]
 }


### PR DESCRIPTION
# Summary | Résumé

Setting up an OIDC role for the SRE Audit tool to be assumed by the GH action