### PR TITLE
Excluding ops1 and ops2 from deny all policy

### DIFF
--- a/terragrunt/org_account/organization/scp.tf
+++ b/terragrunt/org_account/organization/scp.tf
@@ -167,6 +167,11 @@ data "aws_iam_policy_document" "qurantine_deny_all_policy" {
     resources = [
       "*",
     ]
+    condition {
+      test     = "StringNotLike"
+      variable = "aws:username"
+      values   = ["ops1", "ops2"]
+    }
   }
 }
 


### PR DESCRIPTION
# Summary | Résumé

Excluding ops1 and ops2 from the deny all policy. 