### PR TITLE
feat: add IAM Identity Center module

### DIFF
--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -64,6 +64,11 @@ jobs:
             account: 659087519042
             role: cds-aws-lz-apply
 
+          - account_folder: org_account
+            module: iam_identity_center
+            account: 659087519042
+            role: cds-aws-lz-apply            
+
           - account_folder: log_archive
             module: main
             account: 274536870005

--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -56,6 +56,11 @@ jobs:
             account: 659087519042
             role: cds-aws-lz-plan
 
+          - account_folder: org_account
+            module: iam_identity_center
+            account: 659087519042
+            role: cds-aws-lz-plan            
+
           - account_folder: log_archive
             module: main
             account: 274536870005

--- a/terragrunt/org_account/iam_identity_center/data.tf
+++ b/terragrunt/org_account/iam_identity_center/data.tf
@@ -1,0 +1,17 @@
+#
+# AWS default permission sets
+#
+data "aws_ssoadmin_permission_set" "aws_administrator_access" {
+  instance_arn = local.sso_instance_arn
+  name         = "AWSAdministratorAccess"
+}
+
+data "aws_ssoadmin_permission_set" "aws_read_only_access" {
+  instance_arn = local.sso_instance_arn
+  name         = "AWSReadOnlyAccess"
+}
+
+data "aws_ssoadmin_permission_set" "billing" {
+  instance_arn = local.sso_instance_arn
+  name         = "Billing"
+}

--- a/terragrunt/org_account/iam_identity_center/locals.tf
+++ b/terragrunt/org_account/iam_identity_center/locals.tf
@@ -1,0 +1,5 @@
+locals {
+  sso_identity_store_id = "d-9d67173bdd"
+  sso_instance_id       = "ssoins-8824c710b5ddb452"
+  sso_instance_arn      = "arn:aws:sso:::instance/${local.sso_instance_id}"
+}

--- a/terragrunt/org_account/iam_identity_center/platform_articles.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_articles.tf
@@ -84,7 +84,7 @@ resource "aws_ssoadmin_account_assignment" "articles" {
   instance_arn       = local.sso_instance_arn
   permission_set_arn = each.value.permission_set_arn
 
-  principal_id   = each.value.group.principal_id
+  principal_id   = each.value.group.group_id
   principal_type = "GROUP"
 
   target_id   = each.value.target_id

--- a/terragrunt/org_account/iam_identity_center/platform_articles.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_articles.tf
@@ -1,15 +1,39 @@
 #
 # Groups
 #
-resource "aws_identitystore_group" "articles_devs" {
-  display_name      = "GCArticlesDevs"
-  description       = "Grants members access to the GC Articles accounts."
+resource "aws_identitystore_group" "articles_production_access_vpc_clientvpn" {
+  display_name      = "Articles-Production-Access-VPC-ClientVPN"
+  description       = "Grants members access to the GC Articles Production Client VPN."
   identity_store_id = local.sso_identity_store_id
 }
 
-resource "aws_identitystore_group" "articles_vpn" {
-  display_name      = "GCArticlesVPN"
-  description       = "Grants members access to the GC Articles VPN."
+resource "aws_identitystore_group" "articles_production_admin" {
+  display_name      = "Articles-Production-Admin"
+  description       = "Grants members administrator access to the GC Articles Production account."
+  identity_store_id = local.sso_identity_store_id
+}
+
+resource "aws_identitystore_group" "articles_production_read_only" {
+  display_name      = "Articles-Production-ReadOnly"
+  description       = "Grants members read-only access to the GC Articles Production account."
+  identity_store_id = local.sso_identity_store_id
+}
+
+resource "aws_identitystore_group" "articles_staging_access_vpc_clientvpn" {
+  display_name      = "Articles-Staging-Access-VPC-ClientVPN"
+  description       = "Grants members access to the GC Articles Staging Client VPN."
+  identity_store_id = local.sso_identity_store_id
+}
+
+resource "aws_identitystore_group" "articles_staging_admin" {
+  display_name      = "Articles-Staging-Admin"
+  description       = "Grants members administrator access to the GC Articles Staging account."
+  identity_store_id = local.sso_identity_store_id
+}
+
+resource "aws_identitystore_group" "articles_staging_read_only" {
+  display_name      = "Articles-Staging-ReadOnly"
+  description       = "Grants members read-only access to the GC Articles Staging account."
   identity_store_id = local.sso_identity_store_id
 }
 
@@ -18,95 +42,51 @@ resource "aws_identitystore_group" "articles_vpn" {
 #
 locals {
   articles_permission_set_arns = [
+    # GCArticles-Production
     {
-      name = "AWSAdministratorAccess",
-      arn  = data.aws_ssoadmin_permission_set.aws_administrator_access.arn,
+      target_id          = "472286471787"
+      permission_set_arn = data.aws_ssoadmin_permission_set.aws_administrator_access.arn,
+      principal_id       = aws_identitystore_group.articles_production_admin.group_id,
     },
     {
-      name = "AWSReadOnlyAccess",
-      arn  = data.aws_ssoadmin_permission_set.aws_read_only_access.arn,
+      target_id          = "472286471787"
+      permission_set_arn = data.aws_ssoadmin_permission_set.aws_read_only_access.arn,
+      principal_id       = aws_identitystore_group.articles_production_read_only.group_id,
+    },
+    # GCArticles-Staging       
+    {
+      target_id          = "729164266357"
+      principal_id       = aws_identitystore_group.articles_staging_admin.group_id,
+      permission_set_arn = data.aws_ssoadmin_permission_set.aws_administrator_access.arn,
+    },
+    {
+      target_id          = "729164266357"
+      permission_set_arn = data.aws_ssoadmin_permission_set.aws_read_only_access.arn,
+      principal_id       = aws_identitystore_group.articles_staging_read_only.group_id,
+    },
+    # PlatformListManager-Production
+    {
+      target_id          = "762579868088"
+      permission_set_arn = data.aws_ssoadmin_permission_set.aws_administrator_access.arn,
+      principal_id       = aws_identitystore_group.articles_production_admin.group_id,
+    },
+    {
+      target_id          = "762579868088"
+      permission_set_arn = data.aws_ssoadmin_permission_set.aws_read_only_access.arn,
+      principal_id       = aws_identitystore_group.articles_production_read_only.group_id,
     },
   ]
 }
 
-resource "aws_ssoadmin_account_assignment" "articles_devs_staging" {
-  for_each = { for perm in local.articles_permission_set_arns : perm.name => perm }
+resource "aws_ssoadmin_account_assignment" "articles" {
+  for_each = { for perm in local.articles_permission_set_arns : perm.principal_id.name => perm }
 
   instance_arn       = local.sso_instance_arn
-  permission_set_arn = each.value.arn
+  permission_set_arn = each.value.permission_set_arn
 
-  principal_id   = aws_identitystore_group.articles_devs.group_id
+  principal_id   = each.value.principal_id
   principal_type = "GROUP"
 
-  target_id   = "729164266357"
+  target_id   = each.value.target_id
   target_type = "AWS_ACCOUNT"
-}
-
-resource "aws_ssoadmin_account_assignment" "articles_devs_production" {
-  for_each = { for perm in local.articles_permission_set_arns : perm.name => perm }
-
-  instance_arn       = local.sso_instance_arn
-  permission_set_arn = each.value.arn
-
-  principal_id   = aws_identitystore_group.articles_devs.group_id
-  principal_type = "GROUP"
-
-  target_id   = "472286471787"
-  target_type = "AWS_ACCOUNT"
-}
-
-resource "aws_ssoadmin_account_assignment" "articles_devs_platform_list_manager" {
-  for_each = { for perm in local.articles_permission_set_arns : perm.name => perm }
-
-  instance_arn       = local.sso_instance_arn
-  permission_set_arn = each.value.arn
-
-  principal_id   = aws_identitystore_group.articles_devs.group_id
-  principal_type = "GROUP"
-
-  target_id   = "762579868088"
-  target_type = "AWS_ACCOUNT"
-}
-
-#
-# Terraform state imports: remove after merge to `main`
-#
-import {
-  to = aws_identitystore_group.articles_devs
-  id = "${local.sso_identity_store_id}/2c2df578-9041-7052-74b1-a2d362f212bb"
-}
-
-import {
-  to = aws_identitystore_group.articles_vpn
-  id = "${local.sso_identity_store_id}/dccd4518-30d1-7014-0e65-d503dc3c4b75"
-}
-
-import {
-  to = aws_ssoadmin_account_assignment.articles_devs_staging["AWSAdministratorAccess"]
-  id = "2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,729164266357,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_administrator_access.arn},${local.sso_instance_arn}"
-}
-
-import {
-  to = aws_ssoadmin_account_assignment.articles_devs_staging["AWSReadOnlyAccess"]
-  id = "2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,729164266357,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_read_only_access.arn},${local.sso_instance_arn}"
-}
-
-import {
-  to = aws_ssoadmin_account_assignment.articles_devs_production["AWSAdministratorAccess"]
-  id = "2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,472286471787,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_administrator_access.arn},${local.sso_instance_arn}"
-}
-
-import {
-  to = aws_ssoadmin_account_assignment.articles_devs_production["AWSReadOnlyAccess"]
-  id = "2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,472286471787,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_read_only_access.arn},${local.sso_instance_arn}"
-}
-
-import {
-  to = aws_ssoadmin_account_assignment.articles_devs_platform_list_manager["AWSAdministratorAccess"]
-  id = "2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,762579868088,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_administrator_access.arn},${local.sso_instance_arn}"
-}
-
-import {
-  to = aws_ssoadmin_account_assignment.articles_devs_platform_list_manager["AWSReadOnlyAccess"]
-  id = "2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,762579868088,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_read_only_access.arn},${local.sso_instance_arn}"
 }

--- a/terragrunt/org_account/iam_identity_center/platform_articles.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_articles.tf
@@ -79,7 +79,7 @@ locals {
 }
 
 resource "aws_ssoadmin_account_assignment" "articles" {
-  for_each = { for perm in local.articles_permission_set_arns : perm.group.display_name => perm }
+  for_each = { for perm in local.articles_permission_set_arns : "${perm.group.display_name}-${perm.target_id}" => perm }
 
   instance_arn       = local.sso_instance_arn
   permission_set_arn = each.value.permission_set_arn

--- a/terragrunt/org_account/iam_identity_center/platform_articles.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_articles.tf
@@ -79,7 +79,7 @@ locals {
 }
 
 resource "aws_ssoadmin_account_assignment" "articles" {
-  for_each = { for perm in local.articles_permission_set_arns : perm.group.name => perm }
+  for_each = { for perm in local.articles_permission_set_arns : perm.group.display_name => perm }
 
   instance_arn       = local.sso_instance_arn
   permission_set_arn = each.value.permission_set_arn

--- a/terragrunt/org_account/iam_identity_center/platform_articles.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_articles.tf
@@ -77,7 +77,7 @@ import {
 }
 
 import {
-  to = aws_identitystore_group.articls_vpn
+  to = aws_identitystore_group.articles_vpn
   id = "dccd4518-30d1-7014-0e65-d503dc3c4b75"
 }
 

--- a/terragrunt/org_account/iam_identity_center/platform_articles.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_articles.tf
@@ -44,47 +44,47 @@ locals {
   articles_permission_set_arns = [
     # GCArticles-Production
     {
-      target_id          = "472286471787"
+      group              = aws_identitystore_group.articles_production_admin,
       permission_set_arn = data.aws_ssoadmin_permission_set.aws_administrator_access.arn,
-      principal_id       = aws_identitystore_group.articles_production_admin.group_id,
+      target_id          = "472286471787"
     },
     {
-      target_id          = "472286471787"
+      group              = aws_identitystore_group.articles_production_read_only,
       permission_set_arn = data.aws_ssoadmin_permission_set.aws_read_only_access.arn,
-      principal_id       = aws_identitystore_group.articles_production_read_only.group_id,
+      target_id          = "472286471787"
     },
     # GCArticles-Staging       
     {
-      target_id          = "729164266357"
-      principal_id       = aws_identitystore_group.articles_staging_admin.group_id,
+      group              = aws_identitystore_group.articles_staging_admin,
       permission_set_arn = data.aws_ssoadmin_permission_set.aws_administrator_access.arn,
+      target_id          = "729164266357"
     },
     {
-      target_id          = "729164266357"
+      group              = aws_identitystore_group.articles_staging_read_only,
       permission_set_arn = data.aws_ssoadmin_permission_set.aws_read_only_access.arn,
-      principal_id       = aws_identitystore_group.articles_staging_read_only.group_id,
+      target_id          = "729164266357"
     },
     # PlatformListManager-Production
     {
-      target_id          = "762579868088"
+      group              = aws_identitystore_group.articles_production_admin,
       permission_set_arn = data.aws_ssoadmin_permission_set.aws_administrator_access.arn,
-      principal_id       = aws_identitystore_group.articles_production_admin.group_id,
+      target_id          = "762579868088"
     },
     {
-      target_id          = "762579868088"
+      group              = aws_identitystore_group.articles_production_read_only,
       permission_set_arn = data.aws_ssoadmin_permission_set.aws_read_only_access.arn,
-      principal_id       = aws_identitystore_group.articles_production_read_only.group_id,
+      target_id          = "762579868088"
     },
   ]
 }
 
 resource "aws_ssoadmin_account_assignment" "articles" {
-  for_each = { for perm in local.articles_permission_set_arns : perm.principal_id.name => perm }
+  for_each = { for perm in local.articles_permission_set_arns : perm.group.name => perm }
 
   instance_arn       = local.sso_instance_arn
   permission_set_arn = each.value.permission_set_arn
 
-  principal_id   = each.value.principal_id
+  principal_id   = each.value.group.principal_id
   principal_type = "GROUP"
 
   target_id   = each.value.target_id

--- a/terragrunt/org_account/iam_identity_center/platform_articles.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_articles.tf
@@ -73,40 +73,40 @@ resource "aws_ssoadmin_account_assignment" "articles_devs_platform_list_manager"
 #
 import {
   to = aws_identitystore_group.articles_devs
-  id = "2c2df578-9041-7052-74b1-a2d362f212bb"
+  id = "${local.sso_identity_store_id}/2c2df578-9041-7052-74b1-a2d362f212bb"
 }
 
 import {
   to = aws_identitystore_group.articles_vpn
-  id = "dccd4518-30d1-7014-0e65-d503dc3c4b75"
+  id = "${local.sso_identity_store_id}/dccd4518-30d1-7014-0e65-d503dc3c4b75"
 }
 
 import {
   to = aws_ssoadmin_account_assignment.articles_devs_staging["AWSAdministratorAccess"]
-  id = "2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,729164266357,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_administrator_access},${local.sso_instance_arn}"
+  id = "${local.sso_identity_store_id}/2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,729164266357,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_administrator_access},${local.sso_instance_arn}"
 }
 
 import {
   to = aws_ssoadmin_account_assignment.articles_devs_staging["AWSReadOnlyAccess"]
-  id = "2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,729164266357,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_read_only_access},${local.sso_instance_arn}"
+  id = "${local.sso_identity_store_id}/2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,729164266357,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_read_only_access},${local.sso_instance_arn}"
 }
 
 import {
   to = aws_ssoadmin_account_assignment.articles_devs_production["AWSAdministratorAccess"]
-  id = "2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,472286471787,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_administrator_access},${local.sso_instance_arn}"
+  id = "${local.sso_identity_store_id}/2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,472286471787,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_administrator_access},${local.sso_instance_arn}"
 }
 
 import {
   to = aws_ssoadmin_account_assignment.articles_devs_production["AWSReadOnlyAccess"]
-  id = "2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,472286471787,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_read_only_access},${local.sso_instance_arn}"
+  id = "${local.sso_identity_store_id}/2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,472286471787,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_read_only_access},${local.sso_instance_arn}"
 }
 
 import {
   to = aws_ssoadmin_account_assignment.articles_devs_platform_list_manager["AWSAdministratorAccess"]
-  id = "2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,762579868088,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_administrator_access},${local.sso_instance_arn}"
+  id = "${local.sso_identity_store_id}/2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,762579868088,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_administrator_access},${local.sso_instance_arn}"
 }
 
 import {
   to = aws_ssoadmin_account_assignment.articles_devs_platform_list_manager["AWSReadOnlyAccess"]
-  id = "2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,762579868088,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_read_only_access},${local.sso_instance_arn}"
+  id = "${local.sso_identity_store_id}/2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,762579868088,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_read_only_access},${local.sso_instance_arn}"
 }

--- a/terragrunt/org_account/iam_identity_center/platform_articles.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_articles.tf
@@ -1,0 +1,112 @@
+#
+# Groups
+#
+resource "aws_identitystore_group" "articles_devs" {
+  display_name      = "GCArticlesDevs"
+  description       = "Grants members access to the GC Articles accounts."
+  identity_store_id = local.sso_identity_store_id
+}
+
+resource "aws_identitystore_group" "articles_vpn" {
+  display_name      = "GCArticlesVPN"
+  description       = "Grants members access to the GC Articles VPN."
+  identity_store_id = local.sso_identity_store_id
+}
+
+#
+# Accounts: assign groups and permission sets
+#
+locals {
+  articles_permission_set_arns = [
+    {
+      name = "AWSAdministratorAccess",
+      arn  = data.aws_ssoadmin_permission_set.aws_administrator_access.arn,
+    },
+    {
+      name = "AWSReadOnlyAccess",
+      arn  = data.aws_ssoadmin_permission_set.aws_read_only_access.arn,
+    },
+  ]
+}
+
+resource "aws_ssoadmin_account_assignment" "articles_devs_staging" {
+  for_each = { for perm in local.articles_permission_set_arns : perm.name => perm }
+
+  instance_arn       = local.sso_instance_arn
+  permission_set_arn = each.value.arn
+
+  principal_id   = aws_identitystore_group.articles_devs.group_id
+  principal_type = "GROUP"
+
+  target_id   = "729164266357"
+  target_type = "AWS_ACCOUNT"
+}
+
+resource "aws_ssoadmin_account_assignment" "articles_devs_production" {
+  for_each = { for perm in local.articles_permission_set_arns : perm.name => perm }
+
+  instance_arn       = local.sso_instance_arn
+  permission_set_arn = each.value.arn
+
+  principal_id   = aws_identitystore_group.articles_devs.group_id
+  principal_type = "GROUP"
+
+  target_id   = "472286471787"
+  target_type = "AWS_ACCOUNT"
+}
+
+resource "aws_ssoadmin_account_assignment" "articles_devs_platform_list_manager" {
+  for_each = { for perm in local.articles_permission_set_arns : perm.name => perm }
+
+  instance_arn       = local.sso_instance_arn
+  permission_set_arn = each.value.arn
+
+  principal_id   = aws_identitystore_group.articles_devs.group_id
+  principal_type = "GROUP"
+
+  target_id   = "762579868088"
+  target_type = "AWS_ACCOUNT"
+}
+
+#
+# Terraform state imports: remove after merge to `main`
+#
+import {
+  to = aws_identitystore_group.articles_devs
+  id = "2c2df578-9041-7052-74b1-a2d362f212bb"
+}
+
+import {
+  to = aws_identitystore_group.articls_vpn
+  id = "dccd4518-30d1-7014-0e65-d503dc3c4b75"
+}
+
+import {
+  to = aws_ssoadmin_account_assignment.articles_devs_staging["AWSAdministratorAccess"]
+  id = "2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,729164266357,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_administrator_access},${local.sso_instance_arn}"
+}
+
+import {
+  to = aws_ssoadmin_account_assignment.articles_devs_staging["AWSReadOnlyAccess"]
+  id = "2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,729164266357,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_read_only_access},${local.sso_instance_arn}"
+}
+
+import {
+  to = aws_ssoadmin_account_assignment.articles_devs_production["AWSAdministratorAccess"]
+  id = "2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,472286471787,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_administrator_access},${local.sso_instance_arn}"
+}
+
+import {
+  to = aws_ssoadmin_account_assignment.articles_devs_production["AWSReadOnlyAccess"]
+  id = "2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,472286471787,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_read_only_access},${local.sso_instance_arn}"
+}
+
+import {
+  to = aws_ssoadmin_account_assignment.articles_devs_platform_list_manager["AWSAdministratorAccess"]
+  id = "2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,762579868088,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_administrator_access},${local.sso_instance_arn}"
+}
+
+import {
+  to = aws_ssoadmin_account_assignment.articles_devs_platform_list_manager["AWSReadOnlyAccess"]
+  id = "2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,762579868088,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_read_only_access},${local.sso_instance_arn}"
+}

--- a/terragrunt/org_account/iam_identity_center/platform_articles.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_articles.tf
@@ -83,30 +83,30 @@ import {
 
 import {
   to = aws_ssoadmin_account_assignment.articles_devs_staging["AWSAdministratorAccess"]
-  id = "${local.sso_identity_store_id}/2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,729164266357,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_administrator_access},${local.sso_instance_arn}"
+  id = "${local.sso_identity_store_id}/2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,729164266357,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_administrator_access.arn},${local.sso_instance_arn}"
 }
 
 import {
   to = aws_ssoadmin_account_assignment.articles_devs_staging["AWSReadOnlyAccess"]
-  id = "${local.sso_identity_store_id}/2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,729164266357,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_read_only_access},${local.sso_instance_arn}"
+  id = "${local.sso_identity_store_id}/2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,729164266357,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_read_only_access.arn},${local.sso_instance_arn}"
 }
 
 import {
   to = aws_ssoadmin_account_assignment.articles_devs_production["AWSAdministratorAccess"]
-  id = "${local.sso_identity_store_id}/2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,472286471787,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_administrator_access},${local.sso_instance_arn}"
+  id = "${local.sso_identity_store_id}/2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,472286471787,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_administrator_access.arn},${local.sso_instance_arn}"
 }
 
 import {
   to = aws_ssoadmin_account_assignment.articles_devs_production["AWSReadOnlyAccess"]
-  id = "${local.sso_identity_store_id}/2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,472286471787,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_read_only_access},${local.sso_instance_arn}"
+  id = "${local.sso_identity_store_id}/2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,472286471787,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_read_only_access.arn},${local.sso_instance_arn}"
 }
 
 import {
   to = aws_ssoadmin_account_assignment.articles_devs_platform_list_manager["AWSAdministratorAccess"]
-  id = "${local.sso_identity_store_id}/2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,762579868088,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_administrator_access},${local.sso_instance_arn}"
+  id = "${local.sso_identity_store_id}/2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,762579868088,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_administrator_access.arn},${local.sso_instance_arn}"
 }
 
 import {
   to = aws_ssoadmin_account_assignment.articles_devs_platform_list_manager["AWSReadOnlyAccess"]
-  id = "${local.sso_identity_store_id}/2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,762579868088,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_read_only_access},${local.sso_instance_arn}"
+  id = "${local.sso_identity_store_id}/2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,762579868088,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_read_only_access.arn},${local.sso_instance_arn}"
 }

--- a/terragrunt/org_account/iam_identity_center/platform_articles.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_articles.tf
@@ -83,30 +83,30 @@ import {
 
 import {
   to = aws_ssoadmin_account_assignment.articles_devs_staging["AWSAdministratorAccess"]
-  id = "${local.sso_identity_store_id}/2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,729164266357,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_administrator_access.arn},${local.sso_instance_arn}"
+  id = "2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,729164266357,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_administrator_access.arn},${local.sso_instance_arn}"
 }
 
 import {
   to = aws_ssoadmin_account_assignment.articles_devs_staging["AWSReadOnlyAccess"]
-  id = "${local.sso_identity_store_id}/2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,729164266357,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_read_only_access.arn},${local.sso_instance_arn}"
+  id = "2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,729164266357,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_read_only_access.arn},${local.sso_instance_arn}"
 }
 
 import {
   to = aws_ssoadmin_account_assignment.articles_devs_production["AWSAdministratorAccess"]
-  id = "${local.sso_identity_store_id}/2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,472286471787,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_administrator_access.arn},${local.sso_instance_arn}"
+  id = "2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,472286471787,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_administrator_access.arn},${local.sso_instance_arn}"
 }
 
 import {
   to = aws_ssoadmin_account_assignment.articles_devs_production["AWSReadOnlyAccess"]
-  id = "${local.sso_identity_store_id}/2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,472286471787,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_read_only_access.arn},${local.sso_instance_arn}"
+  id = "2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,472286471787,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_read_only_access.arn},${local.sso_instance_arn}"
 }
 
 import {
   to = aws_ssoadmin_account_assignment.articles_devs_platform_list_manager["AWSAdministratorAccess"]
-  id = "${local.sso_identity_store_id}/2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,762579868088,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_administrator_access.arn},${local.sso_instance_arn}"
+  id = "2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,762579868088,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_administrator_access.arn},${local.sso_instance_arn}"
 }
 
 import {
   to = aws_ssoadmin_account_assignment.articles_devs_platform_list_manager["AWSReadOnlyAccess"]
-  id = "${local.sso_identity_store_id}/2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,762579868088,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_read_only_access.arn},${local.sso_instance_arn}"
+  id = "2c2df578-9041-7052-74b1-a2d362f212bb,GROUP,762579868088,AWS_ACCOUNT,${data.aws_ssoadmin_permission_set.aws_read_only_access.arn},${local.sso_instance_arn}"
 }

--- a/terragrunt/org_account/iam_identity_center/terragrunt.hcl
+++ b/terragrunt/org_account/iam_identity_center/terragrunt.hcl
@@ -1,0 +1,3 @@
+include {
+  path = find_in_parent_folders()
+}


### PR DESCRIPTION
# Summary
Add a module that can manage the IAM Identity Center groups, permission sets and account assignments.

This includes the GitHub workflow changes and the GC Articles target state group and account assignments.

# Related
- https://github.com/cds-snc/site-reliability-engineering/issues/1194