### PR TITLE
feat: update permissions to include group memberships managemtn

### DIFF
--- a/terragrunt/org_account/roles/sre_bot.tf
+++ b/terragrunt/org_account/roles/sre_bot.tf
@@ -55,7 +55,9 @@ data "aws_iam_policy_document" "sre_bot_policy" {
       "identitystore:DescribeGroupMembership",
       "identitystore:GetGroupId",
       "identitystore:IsMemberInGroups",
-      "identitystore:GetGroupMembershipId"
+      "identitystore:GetGroupMembershipId",
+      "identitystore:CreateGroupMembership",
+      "identitystore:DeleteGroupMembership"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
# Summary | Résumé

Adding permissions to create and delete group memberships to the SRE bot role.

Required in order to add/remove users from SSO groups via the bot's Integration
