### PR TITLE
feat: add AFT pipeline CloudWatch metric alarm

### DIFF
--- a/terragrunt/aft/notifications/cloudwatch.tf
+++ b/terragrunt/aft/notifications/cloudwatch.tf
@@ -1,0 +1,39 @@
+locals {
+    aft_pipeline_log_groups = toset([
+        "/aws/codebuild/aft-global-customizations-terraform",
+        "/aws/codebuild/aft-account-customizations-terraform"
+    ])
+}
+
+resource "aws_cloudwatch_log_metric_filter" "pipeline_failed" {
+  for_each = local.aft_pipeline_log_groups
+
+  name           = "PipelineFailed"
+  pattern        = "FAILED"
+  log_group_name = each.key
+
+  metric_transformation {
+    name          = "AFTPipelineFailed"
+    namespace     = "AFT"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "pipeline_failed" {
+  for_each = local.aft_pipeline_log_groups
+
+  alarm_name          = "PipelineFailed-${split("/", each.key)[2]}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.pipeline_failed[each.key].metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.pipeline_failed[each.key].metric_transformation[0].namespace
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = 0
+  treat_missing_data  = "notBreaching"
+
+  alarm_description = "AFT pipeline execution has failed"
+  alarm_actions     = [data.aws_sns_topic.aft_failure_notifications.arn]
+  ok_actions        = [data.aws_sns_topic.aft_failure_notifications.arn]
+}

--- a/terragrunt/aft/notifications/cloudwatch.tf
+++ b/terragrunt/aft/notifications/cloudwatch.tf
@@ -1,8 +1,8 @@
 locals {
-    aft_pipeline_log_groups = toset([
-        "/aws/codebuild/aft-global-customizations-terraform",
-        "/aws/codebuild/aft-account-customizations-terraform"
-    ])
+  aft_pipeline_log_groups = toset([
+    "/aws/codebuild/aft-global-customizations-terraform",
+    "/aws/codebuild/aft-account-customizations-terraform"
+  ])
 }
 
 resource "aws_cloudwatch_log_metric_filter" "pipeline_failed" {
@@ -13,7 +13,7 @@ resource "aws_cloudwatch_log_metric_filter" "pipeline_failed" {
   log_group_name = each.key
 
   metric_transformation {
-    name          = "AFTPipelineFailed"
+    name          = "PipelineFailed-${element(split("/", each.key), 3)}"
     namespace     = "AFT"
     value         = "1"
     default_value = "0"
@@ -23,7 +23,7 @@ resource "aws_cloudwatch_log_metric_filter" "pipeline_failed" {
 resource "aws_cloudwatch_metric_alarm" "pipeline_failed" {
   for_each = local.aft_pipeline_log_groups
 
-  alarm_name          = "PipelineFailed-${split("/", each.key)[2]}"
+  alarm_name          = "PipelineFailed-${element(split("/", each.key), 3)}"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
   metric_name         = aws_cloudwatch_log_metric_filter.pipeline_failed[each.key].metric_transformation[0].name


### PR DESCRIPTION
# Summary
Add a CloudWatch metric and alarm to alert when an AFT Terraform pipeline execution fails.