### PR TITLE
fix: add SNS topic for AFT CloudWatch alarms

### DIFF
--- a/terragrunt/aft/notifications/cloudwatch.tf
+++ b/terragrunt/aft/notifications/cloudwatch.tf
@@ -34,6 +34,6 @@ resource "aws_cloudwatch_metric_alarm" "pipeline_failed" {
   treat_missing_data  = "notBreaching"
 
   alarm_description = "AFT pipeline execution has failed"
-  alarm_actions     = [data.aws_sns_topic.aft_failure_notifications.arn]
-  ok_actions        = [data.aws_sns_topic.aft_failure_notifications.arn]
+  alarm_actions     = [data.aws_sns_topic.aft_cloudwatch_alarms.arn]
+  ok_actions        = [data.aws_sns_topic.aft_cloudwatch_alarms.arn]
 }

--- a/terragrunt/aft/notifications/cloudwatch.tf
+++ b/terragrunt/aft/notifications/cloudwatch.tf
@@ -34,6 +34,6 @@ resource "aws_cloudwatch_metric_alarm" "pipeline_failed" {
   treat_missing_data  = "notBreaching"
 
   alarm_description = "AFT pipeline execution has failed"
-  alarm_actions     = [data.aws_sns_topic.aft_cloudwatch_alarms.arn]
-  ok_actions        = [data.aws_sns_topic.aft_cloudwatch_alarms.arn]
+  alarm_actions     = [aws_sns_topic.aft_cloudwatch_alarms.arn]
+  ok_actions        = [aws_sns_topic.aft_cloudwatch_alarms.arn]
 }

--- a/terragrunt/aft/notifications/input.tf
+++ b/terragrunt/aft/notifications/input.tf
@@ -1,4 +1,5 @@
 variable "aft_notifications_hook" {
   type        = string
   description = "(Required) The webhook to post AFT Notifications to"
+  sensitive   = true
 }

--- a/terragrunt/aft/notifications/sns.tf
+++ b/terragrunt/aft/notifications/sns.tf
@@ -1,0 +1,55 @@
+resource "aws_sns_topic" "aft_cloudwatch_alarms" {
+  name              = "aft-cloudwatch-alarms"
+  kms_master_key_id = aws_kms_key.aft_cloudwatch_alarms.id
+
+  tags = {
+    CostCentre = var.billing_code
+    Terraform  = true
+  }
+}
+
+resource "aws_sns_topic_subscription" "aft_cloudwatch_alarms_slack" {
+  topic_arn = aws_sns_topic.cloudwatch_alarms.arn
+  protocol  = "https"
+  endpoint  = var.aft_notifications_hook
+}
+
+resource "aws_kms_key" "aft_cloudwatch_alarms" {
+  # checkov:skip=CKV_AWS_7: key rotation not required for CloudWatch SNS topic's messages
+  description = "KMS key for AFT CloudWatch Alarm SNS topic"
+  policy      = data.aws_iam_policy_document.aft_cloudwatch_alarms.json
+
+  tags = {
+    CostCentre = var.billing_code
+    Terraform  = true
+  }
+}
+
+data "aws_iam_policy_document" "aft_cloudwatch_alarms" {
+  # checkov:skip=CKV_AWS_109: `resources = ["*"]` identifies the KMS key to which the key policy is attached
+  # checkov:skip=CKV_AWS_111: `resources = ["*"]` identifies the KMS key to which the key policy is attached
+  statement {
+    effect    = "Allow"
+    resources = ["*"]
+    actions   = ["kms:*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${var.account_id}:root"]
+    }
+  }
+
+  statement {
+    effect    = "Allow"
+    resources = ["*"]
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey*",
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudwatch.amazonaws.com"]
+    }
+  }
+}

--- a/terragrunt/aft/notifications/sns.tf
+++ b/terragrunt/aft/notifications/sns.tf
@@ -9,7 +9,7 @@ resource "aws_sns_topic" "aft_cloudwatch_alarms" {
 }
 
 resource "aws_sns_topic_subscription" "aft_cloudwatch_alarms_slack" {
-  topic_arn = aws_sns_topic.cloudwatch_alarms.arn
+  topic_arn = aws_sns_topic.aft_cloudwatch_alarms.arn
   protocol  = "https"
   endpoint  = var.aft_notifications_hook
 }


### PR DESCRIPTION
# Summary
Add an SNS topic, subscription and KMS key for the AFT CloudWatch alarms. 

This is required as the `aft-failure-notifications` SNS topic's KMS key does not allow CloudWatch to publish messages.