### PR TITLE
fix: ArnLike IAM condition on Blazer policy

### DIFF
--- a/terragrunt/org_account/iam_identity_center/platform_notify_permissions.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_notify_permissions.tf
@@ -127,7 +127,7 @@ data "aws_iam_policy_document" "notify_access_ecs_blazer" {
     ]
     resources = ["*"]
     condition {
-      test     = "arn_like"
+      test     = "ArnLike"
       variable = "ecs:cluster"
       values = [
         "arn:aws:ecs:ca-central-1:*:cluster/blazer"


### PR DESCRIPTION
# Summary
Update the ECS Blazer inline policy to use the correct `ArnLike` key.

# Related
- https://github.com/cds-snc/site-reliability-engineering/issues/1194