### PR TITLE
fix: rename Identity Center groups and permissions

### DIFF
--- a/terragrunt/org_account/iam_identity_center/platform_articles_groups.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_articles_groups.tf
@@ -2,7 +2,7 @@
 # Production
 #
 resource "aws_identitystore_group" "articles_production_access_vpc_clientvpn" {
-  display_name      = "Articles-Production-Access-VPC-ClientVPN"
+  display_name      = "Articles-Production-VPC-ClientVPN-Access"
   description       = "Grants members access to the GC Articles Production Client VPN."
   identity_store_id = local.sso_identity_store_id
 }
@@ -23,7 +23,7 @@ resource "aws_identitystore_group" "articles_production_read_only" {
 # Staging
 #
 resource "aws_identitystore_group" "articles_staging_access_vpc_clientvpn" {
-  display_name      = "Articles-Staging-Access-VPC-ClientVPN"
+  display_name      = "Articles-Staging-VPC-ClientVPN-Access"
   description       = "Grants members access to the GC Articles Staging Client VPN."
   identity_store_id = local.sso_identity_store_id
 }

--- a/terragrunt/org_account/iam_identity_center/platform_notify_groups.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_notify_groups.tf
@@ -2,19 +2,19 @@
 # Production
 #
 resource "aws_identitystore_group" "notify_production_access_ecs_blazer" {
-  display_name      = "Notify-Production-Access-ECS-Blazer"
+  display_name      = "Notify-Production-ECS-Blazer-Access"
   description       = "Grants members access to the Notify Production account's ECS Blazer task."
   identity_store_id = local.sso_identity_store_id
 }
 
 resource "aws_identitystore_group" "notify_production_access_quicksight" {
-  display_name      = "Notify-Production-Access-QuickSight"
+  display_name      = "Notify-Production-QuickSight-Access"
   description       = "Grants members access to the Notify Production account's QuickSight service."
   identity_store_id = local.sso_identity_store_id
 }
 
 resource "aws_identitystore_group" "notify_production_access_vpc_clientvpn" {
-  display_name      = "Notify-Production-Access-VPC-ClientVPN"
+  display_name      = "Notify-Production-VPC-ClientVPN-Access"
   description       = "Grants members access to the Notify Production Client VPN."
   identity_store_id = local.sso_identity_store_id
 }
@@ -26,25 +26,25 @@ resource "aws_identitystore_group" "notify_production_admin" {
 }
 
 resource "aws_identitystore_group" "notify_production_admin_pinpoint_sms" {
-  display_name      = "Notify-Production-Admin-Pinpoint-SMS"
+  display_name      = "Notify-Production-Pinpoint-SMS-Admin"
   description       = "Grants members administrator access to the Notify Production account's Pinpoint SMS service."
   identity_store_id = local.sso_identity_store_id
 }
 
 resource "aws_identitystore_group" "notify_production_admin_s3_website_assets" {
-  display_name      = "Notify-Production-Admin-S3-WebsiteAssets"
+  display_name      = "Notify-Production-S3-WebsiteAssets-Admin"
   description       = "Grants members administrator access to the Notify Production account's S3 website asset upload buckets."
   identity_store_id = local.sso_identity_store_id
 }
 
 resource "aws_identitystore_group" "notify_production_admin_support_center" {
-  display_name      = "Notify-Production-Admin-SupportCenter"
+  display_name      = "Notify-Production-SupportCenter-Admin"
   description       = "Grants members administrator access to the Notify Production account's Support Center."
   identity_store_id = local.sso_identity_store_id
 }
 
 resource "aws_identitystore_group" "notify_production_read_only_billing" {
-  display_name      = "Notify-Production-ReadOnly-Billing"
+  display_name      = "Notify-Production-Billing-ReadOnly"
   description       = "Grants members read-only Billing and Cost Explorer access to the Notify Production account."
   identity_store_id = local.sso_identity_store_id
 }
@@ -59,13 +59,13 @@ resource "aws_identitystore_group" "notify_production_read_only" {
 # Staging
 #
 resource "aws_identitystore_group" "notify_staging_access_ecs_blazer" {
-  display_name      = "Notify-Staging-Access-ECS-Blazer"
+  display_name      = "Notify-Staging-ECS-Blazer-Access"
   description       = "Grants members access to the Notify Staging account's ECS Blazer task."
   identity_store_id = local.sso_identity_store_id
 }
 
 resource "aws_identitystore_group" "notify_staging_access_vpc_clientvpn" {
-  display_name      = "Notify-Staging-Access-VPC-ClientVPN"
+  display_name      = "Notify-Staging-VPC-ClientVPN-Access"
   description       = "Grants members access to the Notify Staging Client VPN."
   identity_store_id = local.sso_identity_store_id
 }
@@ -77,25 +77,25 @@ resource "aws_identitystore_group" "notify_staging_admin" {
 }
 
 resource "aws_identitystore_group" "notify_staging_admin_pinpoint_sms" {
-  display_name      = "Notify-Staging-Admin-Pinpoint-SMS"
+  display_name      = "Notify-Staging-Pinpoint-SMS-Admin"
   description       = "Grants members administrator access to the Notify Staging account's Pinpoint service."
   identity_store_id = local.sso_identity_store_id
 }
 
 resource "aws_identitystore_group" "notify_staging_admin_s3_website_assets" {
-  display_name      = "Notify-Staging-Admin-S3-WebsiteAssets"
+  display_name      = "Notify-Staging-S3-WebsiteAssets-Admin"
   description       = "Grants members administrator access to the Notify Staging account's S3 website asset upload buckets."
   identity_store_id = local.sso_identity_store_id
 }
 
 resource "aws_identitystore_group" "notify_staging_admin_support_center" {
-  display_name      = "Notify-Staging-Admin-SupportCenter"
+  display_name      = "Notify-Staging-SupportCenter-Admin"
   description       = "Grants members administrator access to the Notify Staging account's Support Center."
   identity_store_id = local.sso_identity_store_id
 }
 
 resource "aws_identitystore_group" "notify_staging_read_only_billing" {
-  display_name      = "Notify-Staging-ReadOnly-Billing"
+  display_name      = "Notify-Staging-Billing-ReadOnly"
   description       = "Grants members read-only Billing and Cost Explorer access to the Notify Staging account."
   identity_store_id = local.sso_identity_store_id
 }
@@ -110,7 +110,7 @@ resource "aws_identitystore_group" "notify_staging_read_only" {
 # Dev
 #
 resource "aws_identitystore_group" "notify_dev_access_vpc_clientvpn" {
-  display_name      = "Notify-Dev-Access-VPC-ClientVPN"
+  display_name      = "Notify-Dev-VPC-ClientVPN-Access"
   description       = "Grants members access to the Notify Dev Client VPN."
   identity_store_id = local.sso_identity_store_id
 }

--- a/terragrunt/org_account/iam_identity_center/platform_notify_permissions.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_notify_permissions.tf
@@ -2,7 +2,7 @@
 # Billing read-only
 #
 resource "aws_ssoadmin_permission_set" "read_only_billing" {
-  name         = "ReadOnly-Billing"
+  name         = "Billing-ReadOnly"
   description  = "Grants read-only access to billing data."
   instance_arn = local.sso_instance_arn
 }
@@ -40,7 +40,7 @@ data "aws_iam_policy_document" "read_only_billing" {
 # Pinpoint SMS admin
 #
 resource "aws_ssoadmin_permission_set" "admin_pinpoint_sms" {
-  name         = "Admin-Pinpoint-SMS"
+  name         = "Pinpoint-SMS-Admin"
   description  = "Grants full access to Pinpoint SMS Voice."
   instance_arn = local.sso_instance_arn
 }
@@ -84,7 +84,7 @@ data "aws_iam_policy_document" "admin_pinpoint_sms" {
 # SSM session connection to the Blazer ECS task
 #
 resource "aws_ssoadmin_permission_set" "notify_access_ecs_blazer" {
-  name         = "Access-ECS-Blazer"
+  name         = "ECS-Blazer-Access"
   description  = "Grants access to the Blazer ECS task using an SSM session."
   instance_arn = local.sso_instance_arn
 }
@@ -140,7 +140,7 @@ data "aws_iam_policy_document" "notify_access_ecs_blazer" {
 # QuickSight
 #
 resource "aws_ssoadmin_permission_set" "admin_s3_website_assets" {
-  name         = "Admin-S3-WebsiteAssets"
+  name         = "S3-NotifyWebsiteAssets-Admin"
   instance_arn = local.sso_instance_arn
 }
 
@@ -192,7 +192,7 @@ data "aws_iam_policy_document" "admin_s3_website_assets" {
 # Support Center admin
 #
 resource "aws_ssoadmin_permission_set" "admin_support_center" {
-  name         = "Admin-SupportCenter"
+  name         = "SupportCenter-Admin"
   instance_arn = local.sso_instance_arn
 }
 
@@ -244,7 +244,7 @@ data "aws_iam_policy_document" "admin_support_center" {
 # QuickSight
 #
 resource "aws_ssoadmin_permission_set" "access_quicksight" {
-  name         = "Access-QuickSight"
+  name         = "QuickSight-Access"
   instance_arn = local.sso_instance_arn
 }
 


### PR DESCRIPTION
# Summary
Update the IAM Identity Center group and permissoin names to put the service name before the role:
```
Product-Env(-Service)(-Resource)-Role
```
This will make it easier for people to identify the service as they grant and revoke access.

# Related
- https://github.com/cds-snc/site-reliability-engineering/issues/1194