### PR TITLE
fix: switch to per account permission assignments

### DIFF
--- a/terragrunt/org_account/iam_identity_center/platform_articles_assignments.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_articles_assignments.tf
@@ -2,45 +2,43 @@
 # Accounts: assign permissions
 #
 locals {
-  articles_permission_set_arns = [
-    # GCArticles-Production
+  # GCArticles-Production
+  articles_production_permission_set_arns = [
     {
       group              = aws_identitystore_group.articles_production_admin,
       permission_set_arn = data.aws_ssoadmin_permission_set.aws_administrator_access.arn,
-      target_id          = local.articles_production_account_id
     },
     {
       group              = aws_identitystore_group.articles_production_read_only,
       permission_set_arn = data.aws_ssoadmin_permission_set.aws_read_only_access.arn,
-      target_id          = local.articles_production_account_id
     },
-    # GCArticles-Staging       
+  ]
+  # GCArticles-Staging
+  articles_staging_permission_set_arns = [
     {
       group              = aws_identitystore_group.articles_staging_admin,
       permission_set_arn = data.aws_ssoadmin_permission_set.aws_administrator_access.arn,
-      target_id          = local.articles_staging_account_id
     },
     {
       group              = aws_identitystore_group.articles_staging_read_only,
       permission_set_arn = data.aws_ssoadmin_permission_set.aws_read_only_access.arn,
-      target_id          = local.articles_staging_account_id
     },
-    # PlatformListManager-Production
+  ]
+  # PlatformListManager-Production
+  list_manager_production_permission_set_arns = [
     {
       group              = aws_identitystore_group.articles_production_admin,
       permission_set_arn = data.aws_ssoadmin_permission_set.aws_administrator_access.arn,
-      target_id          = local.list_manager_production_account_id
     },
     {
       group              = aws_identitystore_group.articles_production_read_only,
       permission_set_arn = data.aws_ssoadmin_permission_set.aws_read_only_access.arn,
-      target_id          = local.list_manager_production_account_id
     },
   ]
 }
 
-resource "aws_ssoadmin_account_assignment" "articles" {
-  for_each = { for perm in local.articles_permission_set_arns : "${perm.group.display_name}-${perm.target_id}" => perm }
+resource "aws_ssoadmin_account_assignment" "articles_production" {
+  for_each = { for perm in local.articles_production_permission_set_arns : perm.group.display_name => perm }
 
   instance_arn       = local.sso_instance_arn
   permission_set_arn = each.value.permission_set_arn
@@ -48,6 +46,32 @@ resource "aws_ssoadmin_account_assignment" "articles" {
   principal_id   = each.value.group.group_id
   principal_type = "GROUP"
 
-  target_id   = each.value.target_id
+  target_id   = local.articles_production_account_id
+  target_type = "AWS_ACCOUNT"
+}
+
+resource "aws_ssoadmin_account_assignment" "articles_staging" {
+  for_each = { for perm in local.articles_staging_permission_set_arns : perm.group.display_name => perm }
+
+  instance_arn       = local.sso_instance_arn
+  permission_set_arn = each.value.permission_set_arn
+
+  principal_id   = each.value.group.group_id
+  principal_type = "GROUP"
+
+  target_id   = local.articles_staging_account_id
+  target_type = "AWS_ACCOUNT"
+}
+
+resource "aws_ssoadmin_account_assignment" "list_manager_production" {
+  for_each = { for perm in local.list_manager_production_permission_set_arns : perm.group.display_name => perm }
+
+  instance_arn       = local.sso_instance_arn
+  permission_set_arn = each.value.permission_set_arn
+
+  principal_id   = each.value.group.group_id
+  principal_type = "GROUP"
+
+  target_id   = local.list_manager_production_account_id
   target_type = "AWS_ACCOUNT"
 }


### PR DESCRIPTION
# Summary
Update the Articles IAM Identity Center permission assignments so that they are explicitly created per account rather than relying on a dynamic account ID.

# Related
- https://github.com/cds-snc/site-reliability-engineering/issues/1194