### PR TITLE
feat: Forms groups and account assignments

### DIFF
--- a/terragrunt/org_account/iam_identity_center/locals.tf
+++ b/terragrunt/org_account/iam_identity_center/locals.tf
@@ -2,6 +2,9 @@ locals {
   articles_production_account_id = "472286471787"
   articles_staging_account_id    = "729164266357"
 
+  forms_production_account_id = "957818836222"
+  forms_staging_account_id    = "687401027353"
+
   list_manager_production_account_id = "762579868088"
 
   notify_production_account_id = "296255494825"

--- a/terragrunt/org_account/iam_identity_center/platform_articles_assignments.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_articles_assignments.tf
@@ -5,43 +5,43 @@ locals {
   # GCArticles-Production
   articles_production_permission_set_arns = [
     {
-      group              = aws_identitystore_group.articles_production_admin,
-      permission_set_arn = data.aws_ssoadmin_permission_set.aws_administrator_access.arn,
+      group          = aws_identitystore_group.articles_production_admin,
+      permission_set = data.aws_ssoadmin_permission_set.aws_administrator_access,
     },
     {
-      group              = aws_identitystore_group.articles_production_read_only,
-      permission_set_arn = data.aws_ssoadmin_permission_set.aws_read_only_access.arn,
+      group          = aws_identitystore_group.articles_production_read_only,
+      permission_set = data.aws_ssoadmin_permission_set.aws_read_only_access,
     },
   ]
   # GCArticles-Staging
   articles_staging_permission_set_arns = [
     {
-      group              = aws_identitystore_group.articles_staging_admin,
-      permission_set_arn = data.aws_ssoadmin_permission_set.aws_administrator_access.arn,
+      group          = aws_identitystore_group.articles_staging_admin,
+      permission_set = data.aws_ssoadmin_permission_set.aws_administrator_access,
     },
     {
-      group              = aws_identitystore_group.articles_staging_read_only,
-      permission_set_arn = data.aws_ssoadmin_permission_set.aws_read_only_access.arn,
+      group          = aws_identitystore_group.articles_staging_read_only,
+      permission_set = data.aws_ssoadmin_permission_set.aws_read_only_access,
     },
   ]
   # PlatformListManager-Production
   list_manager_production_permission_set_arns = [
     {
-      group              = aws_identitystore_group.articles_production_admin,
-      permission_set_arn = data.aws_ssoadmin_permission_set.aws_administrator_access.arn,
+      group          = aws_identitystore_group.articles_production_admin,
+      permission_set = data.aws_ssoadmin_permission_set.aws_administrator_access,
     },
     {
-      group              = aws_identitystore_group.articles_production_read_only,
-      permission_set_arn = data.aws_ssoadmin_permission_set.aws_read_only_access.arn,
+      group          = aws_identitystore_group.articles_production_read_only,
+      permission_set = data.aws_ssoadmin_permission_set.aws_read_only_access,
     },
   ]
 }
 
 resource "aws_ssoadmin_account_assignment" "articles_production" {
-  for_each = { for perm in local.articles_production_permission_set_arns : perm.group.display_name => perm }
+  for_each = { for perm in local.articles_production_permission_set_arns : "${perm.group.display_name}-${perm.permission_set.name}" => perm }
 
   instance_arn       = local.sso_instance_arn
-  permission_set_arn = each.value.permission_set_arn
+  permission_set_arn = each.value.permission_set.arn
 
   principal_id   = each.value.group.group_id
   principal_type = "GROUP"
@@ -51,10 +51,10 @@ resource "aws_ssoadmin_account_assignment" "articles_production" {
 }
 
 resource "aws_ssoadmin_account_assignment" "articles_staging" {
-  for_each = { for perm in local.articles_staging_permission_set_arns : perm.group.display_name => perm }
+  for_each = { for perm in local.articles_staging_permission_set_arns : "${perm.group.display_name}-${perm.permission_set.name}" => perm }
 
   instance_arn       = local.sso_instance_arn
-  permission_set_arn = each.value.permission_set_arn
+  permission_set_arn = each.value.permission_set.arn
 
   principal_id   = each.value.group.group_id
   principal_type = "GROUP"
@@ -64,14 +64,44 @@ resource "aws_ssoadmin_account_assignment" "articles_staging" {
 }
 
 resource "aws_ssoadmin_account_assignment" "list_manager_production" {
-  for_each = { for perm in local.list_manager_production_permission_set_arns : perm.group.display_name => perm }
+  for_each = { for perm in local.list_manager_production_permission_set_arns : "${perm.group.display_name}-${perm.permission_set.name}" => perm }
 
   instance_arn       = local.sso_instance_arn
-  permission_set_arn = each.value.permission_set_arn
+  permission_set_arn = each.value.permission_set.arn
 
   principal_id   = each.value.group.group_id
   principal_type = "GROUP"
 
   target_id   = local.list_manager_production_account_id
   target_type = "AWS_ACCOUNT"
+}
+
+moved {
+  from = aws_ssoadmin_account_assignment.articles_production["Articles-Production-Admin"]
+  to   = aws_ssoadmin_account_assignment.articles_production["Articles-Production-Admin-AWSAdministratorAccess"]
+}
+
+moved {
+  from = aws_ssoadmin_account_assignment.articles_production["Articles-Production-ReadOnly"]
+  to   = aws_ssoadmin_account_assignment.articles_production["Articles-Production-ReadOnly-AWSReadOnlyAccess"]
+}
+
+moved {
+  from = aws_ssoadmin_account_assignment.articles_staging["Articles-Staging-Admin"]
+  to   = aws_ssoadmin_account_assignment.articles_staging["Articles-Staging-Admin-AWSAdministratorAccess"]
+}
+
+moved {
+  from = aws_ssoadmin_account_assignment.articles_staging["Articles-Staging-ReadOnly"]
+  to   = aws_ssoadmin_account_assignment.articles_staging["Articles-Staging-ReadOnly-AWSReadOnlyAccess"]
+}
+
+moved {
+  from = aws_ssoadmin_account_assignment.list_manager_production["Articles-Production-Admin"]
+  to   = aws_ssoadmin_account_assignment.list_manager_production["Articles-Production-Admin-AWSAdministratorAccess"]
+}
+
+moved {
+  from = aws_ssoadmin_account_assignment.list_manager_production["Articles-Production-ReadOnly"]
+  to   = aws_ssoadmin_account_assignment.list_manager_production["Articles-Production-ReadOnly-AWSReadOnlyAccess"]
 }

--- a/terragrunt/org_account/iam_identity_center/platform_articles_assignments.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_articles_assignments.tf
@@ -3,7 +3,7 @@
 #
 locals {
   # GCArticles-Production
-  articles_production_permission_set_arns = [
+  articles_production_permission_sets = [
     {
       group          = aws_identitystore_group.articles_production_admin,
       permission_set = data.aws_ssoadmin_permission_set.aws_administrator_access,
@@ -14,7 +14,7 @@ locals {
     },
   ]
   # GCArticles-Staging
-  articles_staging_permission_set_arns = [
+  articles_staging_permission_sets = [
     {
       group          = aws_identitystore_group.articles_staging_admin,
       permission_set = data.aws_ssoadmin_permission_set.aws_administrator_access,
@@ -25,7 +25,7 @@ locals {
     },
   ]
   # PlatformListManager-Production
-  list_manager_production_permission_set_arns = [
+  list_manager_production_permission_sets = [
     {
       group          = aws_identitystore_group.articles_production_admin,
       permission_set = data.aws_ssoadmin_permission_set.aws_administrator_access,
@@ -38,7 +38,7 @@ locals {
 }
 
 resource "aws_ssoadmin_account_assignment" "articles_production" {
-  for_each = { for perm in local.articles_production_permission_set_arns : "${perm.group.display_name}-${perm.permission_set.name}" => perm }
+  for_each = { for perm in local.articles_production_permission_sets : "${perm.group.display_name}-${perm.permission_set.name}" => perm }
 
   instance_arn       = local.sso_instance_arn
   permission_set_arn = each.value.permission_set.arn
@@ -51,7 +51,7 @@ resource "aws_ssoadmin_account_assignment" "articles_production" {
 }
 
 resource "aws_ssoadmin_account_assignment" "articles_staging" {
-  for_each = { for perm in local.articles_staging_permission_set_arns : "${perm.group.display_name}-${perm.permission_set.name}" => perm }
+  for_each = { for perm in local.articles_staging_permission_sets : "${perm.group.display_name}-${perm.permission_set.name}" => perm }
 
   instance_arn       = local.sso_instance_arn
   permission_set_arn = each.value.permission_set.arn
@@ -64,7 +64,7 @@ resource "aws_ssoadmin_account_assignment" "articles_staging" {
 }
 
 resource "aws_ssoadmin_account_assignment" "list_manager_production" {
-  for_each = { for perm in local.list_manager_production_permission_set_arns : "${perm.group.display_name}-${perm.permission_set.name}" => perm }
+  for_each = { for perm in local.list_manager_production_permission_sets : "${perm.group.display_name}-${perm.permission_set.name}" => perm }
 
   instance_arn       = local.sso_instance_arn
   permission_set_arn = each.value.permission_set.arn

--- a/terragrunt/org_account/iam_identity_center/platform_forms_assignments.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_forms_assignments.tf
@@ -25,7 +25,7 @@ locals {
     },
     {
       group              = aws_identitystore_group.forms_staging_read_only,
-      permission_set_arn = data.aws_ssoadmin_permission_set.read_only_billing.arn,
+      permission_set_arn = aws_ssoadmin_permission_set.read_only_billing.arn,
     },
   ]
 }

--- a/terragrunt/org_account/iam_identity_center/platform_forms_assignments.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_forms_assignments.tf
@@ -5,36 +5,36 @@ locals {
   # Forms-Production
   forms_production_permission_set_arns = [
     {
-      group              = aws_identitystore_group.forms_production_admin,
-      permission_set_arn = data.aws_ssoadmin_permission_set.aws_administrator_access.arn,
+      group          = aws_identitystore_group.forms_production_admin,
+      permission_set = data.aws_ssoadmin_permission_set.aws_administrator_access,
     },
     {
-      group              = aws_identitystore_group.forms_production_read_only,
-      permission_set_arn = data.aws_ssoadmin_permission_set.aws_read_only_access.arn,
+      group          = aws_identitystore_group.forms_production_read_only,
+      permission_set = data.aws_ssoadmin_permission_set.aws_read_only_access,
     },
   ]
   # Forms-Staging
   forms_staging_permission_set_arns = [
     {
-      group              = aws_identitystore_group.forms_staging_admin,
-      permission_set_arn = data.aws_ssoadmin_permission_set.aws_administrator_access.arn,
+      group          = aws_identitystore_group.forms_staging_admin,
+      permission_set = data.aws_ssoadmin_permission_set.aws_administrator_access,
     },
     {
-      group              = aws_identitystore_group.forms_staging_read_only,
-      permission_set_arn = data.aws_ssoadmin_permission_set.aws_read_only_access.arn,
+      group          = aws_identitystore_group.forms_staging_read_only,
+      permission_set = data.aws_ssoadmin_permission_set.aws_read_only_access,
     },
     {
-      group              = aws_identitystore_group.forms_staging_read_only,
-      permission_set_arn = aws_ssoadmin_permission_set.read_only_billing.arn,
+      group          = aws_identitystore_group.forms_staging_read_only,
+      permission_set = aws_ssoadmin_permission_set.read_only_billing,
     },
   ]
 }
 
 resource "aws_ssoadmin_account_assignment" "forms_production" {
-  for_each = { for perm in local.forms_production_permission_set_arns : perm.group.display_name => perm }
+  for_each = { for perm in local.forms_production_permission_set_arns : "${perm.group.display_name}-${perm.permission_set.name}" => perm }
 
   instance_arn       = local.sso_instance_arn
-  permission_set_arn = each.value.permission_set_arn
+  permission_set_arn = each.value.permission_set.arn
 
   principal_id   = each.value.group.group_id
   principal_type = "GROUP"
@@ -44,10 +44,10 @@ resource "aws_ssoadmin_account_assignment" "forms_production" {
 }
 
 resource "aws_ssoadmin_account_assignment" "forms_staging" {
-  for_each = { for perm in local.forms_staging_permission_set_arns : perm.group.display_name => perm }
+  for_each = { for perm in local.forms_staging_permission_set_arns : "${perm.group.display_name}-${perm.permission_set.name}" => perm }
 
   instance_arn       = local.sso_instance_arn
-  permission_set_arn = each.value.permission_set_arn
+  permission_set_arn = each.value.permission_set.arn
 
   principal_id   = each.value.group.group_id
   principal_type = "GROUP"

--- a/terragrunt/org_account/iam_identity_center/platform_forms_assignments.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_forms_assignments.tf
@@ -3,7 +3,7 @@
 #
 locals {
   # Forms-Production
-  forms_production_permission_set_arns = [
+  forms_production_permission_sets = [
     {
       group          = aws_identitystore_group.forms_production_admin,
       permission_set = data.aws_ssoadmin_permission_set.aws_administrator_access,
@@ -14,7 +14,7 @@ locals {
     },
   ]
   # Forms-Staging
-  forms_staging_permission_set_arns = [
+  forms_staging_permission_sets = [
     {
       group          = aws_identitystore_group.forms_staging_admin,
       permission_set = data.aws_ssoadmin_permission_set.aws_administrator_access,
@@ -31,7 +31,7 @@ locals {
 }
 
 resource "aws_ssoadmin_account_assignment" "forms_production" {
-  for_each = { for perm in local.forms_production_permission_set_arns : "${perm.group.display_name}-${perm.permission_set.name}" => perm }
+  for_each = { for perm in local.forms_production_permission_sets : "${perm.group.display_name}-${perm.permission_set.name}" => perm }
 
   instance_arn       = local.sso_instance_arn
   permission_set_arn = each.value.permission_set.arn
@@ -44,7 +44,7 @@ resource "aws_ssoadmin_account_assignment" "forms_production" {
 }
 
 resource "aws_ssoadmin_account_assignment" "forms_staging" {
-  for_each = { for perm in local.forms_staging_permission_set_arns : "${perm.group.display_name}-${perm.permission_set.name}" => perm }
+  for_each = { for perm in local.forms_staging_permission_sets : "${perm.group.display_name}-${perm.permission_set.name}" => perm }
 
   instance_arn       = local.sso_instance_arn
   permission_set_arn = each.value.permission_set.arn

--- a/terragrunt/org_account/iam_identity_center/platform_forms_assignments.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_forms_assignments.tf
@@ -1,0 +1,57 @@
+#
+# Accounts: assign permissions
+#
+locals {
+  # Forms-Production
+  forms_production_permission_set_arns = [
+    {
+      group              = aws_identitystore_group.forms_production_admin,
+      permission_set_arn = data.aws_ssoadmin_permission_set.aws_administrator_access.arn,
+    },
+    {
+      group              = aws_identitystore_group.forms_production_read_only,
+      permission_set_arn = data.aws_ssoadmin_permission_set.aws_read_only_access.arn,
+    },
+  ]
+  # Forms-Staging
+  forms_staging_permission_set_arns = [
+    {
+      group              = aws_identitystore_group.forms_staging_admin,
+      permission_set_arn = data.aws_ssoadmin_permission_set.aws_administrator_access.arn,
+    },
+    {
+      group              = aws_identitystore_group.forms_staging_read_only,
+      permission_set_arn = data.aws_ssoadmin_permission_set.aws_read_only_access.arn,
+    },
+    {
+      group              = aws_identitystore_group.forms_staging_read_only,
+      permission_set_arn = data.aws_ssoadmin_permission_set.read_only_billing.arn,
+    },
+  ]
+}
+
+resource "aws_ssoadmin_account_assignment" "forms_production" {
+  for_each = { for perm in local.forms_production_permission_set_arns : perm.group.display_name => perm }
+
+  instance_arn       = local.sso_instance_arn
+  permission_set_arn = each.value.permission_set_arn
+
+  principal_id   = each.value.group.group_id
+  principal_type = "GROUP"
+
+  target_id   = local.forms_production_account_id
+  target_type = "AWS_ACCOUNT"
+}
+
+resource "aws_ssoadmin_account_assignment" "forms_staging" {
+  for_each = { for perm in local.forms_staging_permission_set_arns : perm.group.display_name => perm }
+
+  instance_arn       = local.sso_instance_arn
+  permission_set_arn = each.value.permission_set_arn
+
+  principal_id   = each.value.group.group_id
+  principal_type = "GROUP"
+
+  target_id   = local.forms_staging_account_id
+  target_type = "AWS_ACCOUNT"
+}

--- a/terragrunt/org_account/iam_identity_center/platform_forms_groups.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_forms_groups.tf
@@ -1,0 +1,29 @@
+#
+# Production
+#
+resource "aws_identitystore_group" "forms_production_admin" {
+  display_name      = "Forms-Production-Admin"
+  description       = "Grants members administrator access to the GC Forms Production account."
+  identity_store_id = local.sso_identity_store_id
+}
+
+resource "aws_identitystore_group" "forms_production_read_only" {
+  display_name      = "Forms-Production-ReadOnly"
+  description       = "Grants members read-only access to the GC Forms Production account."
+  identity_store_id = local.sso_identity_store_id
+}
+
+#
+# Staging
+#
+resource "aws_identitystore_group" "forms_staging_admin" {
+  display_name      = "Forms-Staging-Admin"
+  description       = "Grants members administrator access to the GC Forms Staging account."
+  identity_store_id = local.sso_identity_store_id
+}
+
+resource "aws_identitystore_group" "forms_staging_read_only" {
+  display_name      = "Forms-Staging-ReadOnly"
+  description       = "Grants members read-only access to the GC Forms Staging account."
+  identity_store_id = local.sso_identity_store_id
+}

--- a/terragrunt/org_account/iam_identity_center/platform_notify_assignments.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_notify_assignments.tf
@@ -3,100 +3,100 @@
 #
 locals {
   # Notification-Production
-  notify_production_permission_set_arns = [
+  notify_production_permission_sets = [
     {
-      group              = aws_identitystore_group.notify_production_access_ecs_blazer,
-      permission_set_arn = aws_ssoadmin_permission_set.notify_access_ecs_blazer.arn,
+      group          = aws_identitystore_group.notify_production_access_ecs_blazer,
+      permission_set = aws_ssoadmin_permission_set.notify_access_ecs_blazer,
     },
     {
-      group              = aws_identitystore_group.notify_production_access_quicksight,
-      permission_set_arn = aws_ssoadmin_permission_set.quicksight.arn,
+      group          = aws_identitystore_group.notify_production_access_quicksight,
+      permission_set = aws_ssoadmin_permission_set.quicksight,
     },
     {
-      group              = aws_identitystore_group.notify_production_admin,
-      permission_set_arn = data.aws_ssoadmin_permission_set.aws_administrator_access.arn,
+      group          = aws_identitystore_group.notify_production_admin,
+      permission_set = data.aws_ssoadmin_permission_set.aws_administrator_access,
     },
     {
-      group              = aws_identitystore_group.notify_production_admin_pinpoint_sms,
-      permission_set_arn = aws_ssoadmin_permission_set.admin_pinpoint_sms.arn,
+      group          = aws_identitystore_group.notify_production_admin_pinpoint_sms,
+      permission_set = aws_ssoadmin_permission_set.admin_pinpoint_sms,
     },
     {
-      group              = aws_identitystore_group.notify_production_admin_s3_website_assets,
-      permission_set_arn = aws_ssoadmin_permission_set.admin_s3_website_assets.arn,
+      group          = aws_identitystore_group.notify_production_admin_s3_website_assets,
+      permission_set = aws_ssoadmin_permission_set.admin_s3_website_assets,
     },
     {
-      group              = aws_identitystore_group.notify_production_admin_support_center,
-      permission_set_arn = aws_ssoadmin_permission_set.admin_support_center.arn,
+      group          = aws_identitystore_group.notify_production_admin_support_center,
+      permission_set = aws_ssoadmin_permission_set.admin_support_center,
     },
     {
-      group              = aws_identitystore_group.notify_production_read_only_billing,
-      permission_set_arn = aws_ssoadmin_permission_set.read_only_billing.arn,
+      group          = aws_identitystore_group.notify_production_read_only_billing,
+      permission_set = aws_ssoadmin_permission_set.read_only_billing,
     },
     {
-      group              = aws_identitystore_group.notify_production_read_only,
-      permission_set_arn = data.aws_ssoadmin_permission_set.aws_read_only_access.arn,
+      group          = aws_identitystore_group.notify_production_read_only,
+      permission_set = data.aws_ssoadmin_permission_set.aws_read_only_access,
     }
   ]
   # Notification-Staging
-  notify_staging_permission_set_arns = [
+  notify_staging_permission_sets = [
     {
-      group              = aws_identitystore_group.notify_staging_access_ecs_blazer,
-      permission_set_arn = aws_ssoadmin_permission_set.notify_access_ecs_blazer.arn,
+      group          = aws_identitystore_group.notify_staging_access_ecs_blazer,
+      permission_set = aws_ssoadmin_permission_set.notify_access_ecs_blazer,
     },
     {
-      group              = aws_identitystore_group.notify_staging_admin,
-      permission_set_arn = data.aws_ssoadmin_permission_set.aws_administrator_access.arn,
+      group          = aws_identitystore_group.notify_staging_admin,
+      permission_set = data.aws_ssoadmin_permission_set.aws_administrator_access,
     },
     {
-      group              = aws_identitystore_group.notify_staging_admin_pinpoint_sms,
-      permission_set_arn = aws_ssoadmin_permission_set.admin_pinpoint_sms.arn,
+      group          = aws_identitystore_group.notify_staging_admin_pinpoint_sms,
+      permission_set = aws_ssoadmin_permission_set.admin_pinpoint_sms,
     },
     {
-      group              = aws_identitystore_group.notify_staging_admin_s3_website_assets,
-      permission_set_arn = aws_ssoadmin_permission_set.admin_s3_website_assets.arn,
+      group          = aws_identitystore_group.notify_staging_admin_s3_website_assets,
+      permission_set = aws_ssoadmin_permission_set.admin_s3_website_assets,
     },
     {
-      group              = aws_identitystore_group.notify_staging_admin_support_center,
-      permission_set_arn = aws_ssoadmin_permission_set.admin_support_center.arn,
+      group          = aws_identitystore_group.notify_staging_admin_support_center,
+      permission_set = aws_ssoadmin_permission_set.admin_support_center,
     },
     {
-      group              = aws_identitystore_group.notify_staging_read_only_billing,
-      permission_set_arn = aws_ssoadmin_permission_set.read_only_billing.arn,
+      group          = aws_identitystore_group.notify_staging_read_only_billing,
+      permission_set = aws_ssoadmin_permission_set.read_only_billing,
     },
     {
-      group              = aws_identitystore_group.notify_staging_read_only,
-      permission_set_arn = data.aws_ssoadmin_permission_set.aws_read_only_access.arn,
+      group          = aws_identitystore_group.notify_staging_read_only,
+      permission_set = data.aws_ssoadmin_permission_set.aws_read_only_access,
     }
   ]
   # Notification-Dev
-  notify_dev_permission_set_arns = [
+  notify_dev_permission_sets = [
     {
-      group              = aws_identitystore_group.notify_dev_admin,
-      permission_set_arn = data.aws_ssoadmin_permission_set.aws_administrator_access.arn,
+      group          = aws_identitystore_group.notify_dev_admin,
+      permission_set = data.aws_ssoadmin_permission_set.aws_administrator_access,
     },
     {
-      group              = aws_identitystore_group.notify_dev_read_only,
-      permission_set_arn = data.aws_ssoadmin_permission_set.aws_read_only_access.arn,
+      group          = aws_identitystore_group.notify_dev_read_only,
+      permission_set = data.aws_ssoadmin_permission_set.aws_read_only_access,
     },
   ]
   # Notification-Sandbox
-  notify_sandbox_permission_set_arns = [
+  notify_sandbox_permission_sets = [
     {
-      group              = aws_identitystore_group.notify_sandbox_admin,
-      permission_set_arn = data.aws_ssoadmin_permission_set.aws_administrator_access.arn,
+      group          = aws_identitystore_group.notify_sandbox_admin,
+      permission_set = data.aws_ssoadmin_permission_set.aws_administrator_access,
     },
     {
-      group              = aws_identitystore_group.notify_sandbox_read_only,
-      permission_set_arn = data.aws_ssoadmin_permission_set.aws_read_only_access.arn,
+      group          = aws_identitystore_group.notify_sandbox_read_only,
+      permission_set = data.aws_ssoadmin_permission_set.aws_read_only_access,
     },
   ]
 }
 
 resource "aws_ssoadmin_account_assignment" "notify_production" {
-  for_each = { for perm in local.notify_production_permission_set_arns : perm.group.display_name => perm }
+  for_each = { for perm in local.notify_production_permission_sets : "${perm.group.display_name}-${perm.permission_set.name}" => perm }
 
   instance_arn       = local.sso_instance_arn
-  permission_set_arn = each.value.permission_set_arn
+  permission_set_arn = each.value.permission_set.arn
 
   principal_id   = each.value.group.group_id
   principal_type = "GROUP"
@@ -106,10 +106,10 @@ resource "aws_ssoadmin_account_assignment" "notify_production" {
 }
 
 resource "aws_ssoadmin_account_assignment" "notify_staging" {
-  for_each = { for perm in local.notify_staging_permission_set_arns : perm.group.display_name => perm }
+  for_each = { for perm in local.notify_staging_permission_sets : "${perm.group.display_name}-${perm.permission_set.name}" => perm }
 
   instance_arn       = local.sso_instance_arn
-  permission_set_arn = each.value.permission_set_arn
+  permission_set_arn = each.value.permission_set.arn
 
   principal_id   = each.value.group.group_id
   principal_type = "GROUP"
@@ -119,10 +119,10 @@ resource "aws_ssoadmin_account_assignment" "notify_staging" {
 }
 
 resource "aws_ssoadmin_account_assignment" "notify_dev" {
-  for_each = { for perm in local.notify_dev_permission_set_arns : perm.group.display_name => perm }
+  for_each = { for perm in local.notify_dev_permission_sets : "${perm.group.display_name}-${perm.permission_set.name}" => perm }
 
   instance_arn       = local.sso_instance_arn
-  permission_set_arn = each.value.permission_set_arn
+  permission_set_arn = each.value.permission_set.arn
 
   principal_id   = each.value.group.group_id
   principal_type = "GROUP"
@@ -132,14 +132,109 @@ resource "aws_ssoadmin_account_assignment" "notify_dev" {
 }
 
 resource "aws_ssoadmin_account_assignment" "notify_sandbox" {
-  for_each = { for perm in local.notify_sandbox_permission_set_arns : perm.group.display_name => perm }
+  for_each = { for perm in local.notify_sandbox_permission_sets : "${perm.group.display_name}-${perm.permission_set.name}" => perm }
 
   instance_arn       = local.sso_instance_arn
-  permission_set_arn = each.value.permission_set_arn
+  permission_set_arn = each.value.permission_set.arn
 
   principal_id   = each.value.group.group_id
   principal_type = "GROUP"
 
   target_id   = local.notify_sandbox_account_id
   target_type = "AWS_ACCOUNT"
+}
+
+moved {
+  from = aws_ssoadmin_account_assignment.notify_dev["Notify-Dev-Admin"]
+  to   = aws_ssoadmin_account_assignment.notify_dev["Notify-Dev-Admin-AWSAdministratorAccess"]
+}
+
+moved {
+  from = aws_ssoadmin_account_assignment.notify_dev["Notify-Dev-ReadOnly"]
+  to   = aws_ssoadmin_account_assignment.notify_dev["Notify-Dev-ReadOnly-AWSReadOnlyAccess"]
+}
+
+moved {
+  from = aws_ssoadmin_account_assignment.notify_production["Notify-Production-Admin"]
+  to   = aws_ssoadmin_account_assignment.notify_production["Notify-Production-Admin-AWSAdministratorAccess"]
+}
+
+moved {
+  from = aws_ssoadmin_account_assignment.notify_production["Notify-Production-Billing-ReadOnly"]
+  to   = aws_ssoadmin_account_assignment.notify_production["Notify-Production-Billing-ReadOnly-Billing-ReadOnly"]
+}
+
+moved {
+  from = aws_ssoadmin_account_assignment.notify_production["Notify-Production-ECS-Blazer-Access"]
+  to   = aws_ssoadmin_account_assignment.notify_production["Notify-Production-ECS-Blazer-Access-ECS-Blazer-Access"]
+}
+
+moved {
+  from = aws_ssoadmin_account_assignment.notify_production["Notify-Production-Pinpoint-SMS-Admin"]
+  to   = aws_ssoadmin_account_assignment.notify_production["Notify-Production-Pinpoint-SMS-Admin-Pinpoint-SMS-Admin"]
+}
+
+moved {
+  from = aws_ssoadmin_account_assignment.notify_production["Notify-Production-QuickSight-Access"]
+  to   = aws_ssoadmin_account_assignment.notify_production["Notify-Production-QuickSight-Access-Quicksight"]
+}
+
+moved {
+  from = aws_ssoadmin_account_assignment.notify_production["Notify-Production-ReadOnly"]
+  to   = aws_ssoadmin_account_assignment.notify_production["Notify-Production-ReadOnly-AWSReadOnlyAccess"]
+}
+
+moved {
+  from = aws_ssoadmin_account_assignment.notify_production["Notify-Production-S3-WebsiteAssets-Admin"]
+  to   = aws_ssoadmin_account_assignment.notify_production["Notify-Production-S3-WebsiteAssets-Admin-S3-NotifyWebsiteAssets-Admin"]
+}
+
+moved {
+  from = aws_ssoadmin_account_assignment.notify_production["Notify-Production-SupportCenter-Admin"]
+  to   = aws_ssoadmin_account_assignment.notify_production["Notify-Production-SupportCenter-Admin-SupportCenter-Admin"]
+}
+
+moved {
+  from = aws_ssoadmin_account_assignment.notify_sandbox["Notify-Sandbox-Admin"]
+  to   = aws_ssoadmin_account_assignment.notify_sandbox["Notify-Sandbox-Admin-AWSAdministratorAccess"]
+}
+
+moved {
+  from = aws_ssoadmin_account_assignment.notify_sandbox["Notify-Sandbox-ReadOnly"]
+  to   = aws_ssoadmin_account_assignment.notify_sandbox["Notify-Sandbox-ReadOnly-AWSReadOnlyAccess"]
+}
+
+moved {
+  from = aws_ssoadmin_account_assignment.notify_staging["Notify-Staging-Admin"]
+  to   = aws_ssoadmin_account_assignment.notify_staging["Notify-Staging-Admin-AWSAdministratorAccess"]
+}
+
+moved {
+  from = aws_ssoadmin_account_assignment.notify_staging["Notify-Staging-Billing-ReadOnly"]
+  to   = aws_ssoadmin_account_assignment.notify_staging["Notify-Staging-Billing-ReadOnly-Billing-ReadOnly"]
+}
+
+moved {
+  from = aws_ssoadmin_account_assignment.notify_staging["Notify-Staging-ECS-Blazer-Access"]
+  to   = aws_ssoadmin_account_assignment.notify_staging["Notify-Staging-ECS-Blazer-Access-ECS-Blazer-Access"]
+}
+
+moved {
+  from = aws_ssoadmin_account_assignment.notify_staging["Notify-Staging-Pinpoint-SMS-Admin"]
+  to   = aws_ssoadmin_account_assignment.notify_staging["Notify-Staging-Pinpoint-SMS-Admin-Pinpoint-SMS-Admin"]
+}
+
+moved {
+  from = aws_ssoadmin_account_assignment.notify_staging["Notify-Staging-ReadOnly"]
+  to   = aws_ssoadmin_account_assignment.notify_staging["Notify-Staging-ReadOnly-AWSReadOnlyAccess"]
+}
+
+moved {
+  from = aws_ssoadmin_account_assignment.notify_staging["Notify-Staging-S3-WebsiteAssets-Admin"]
+  to   = aws_ssoadmin_account_assignment.notify_staging["Notify-Staging-S3-WebsiteAssets-Admin-S3-NotifyWebsiteAssets-Admin"]
+}
+
+moved {
+  from = aws_ssoadmin_account_assignment.notify_staging["Notify-Staging-SupportCenter-Admin"]
+  to   = aws_ssoadmin_account_assignment.notify_staging["Notify-Staging-SupportCenter-Admin-SupportCenter-Admin"]
 }


### PR DESCRIPTION
# Summary
Add the Forms groups and their account permission set assignments.

Refactor the Notify and Articles permission assignment Terraform state references to match the Forms' assignments.  This gives more flexibility in assigning multiple permission sets to a group.

# Related
- https://github.com/cds-snc/site-reliability-engineering/issues/1194