### PR TITLE
feat: Forms RDS query editor access group

### DIFF
--- a/terragrunt/org_account/iam_identity_center/platform_forms_assignments.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_forms_assignments.tf
@@ -9,8 +9,16 @@ locals {
       permission_set = data.aws_ssoadmin_permission_set.aws_administrator_access,
     },
     {
+      group          = aws_identitystore_group.forms_production_rds_query_access,
+      permission_set = aws_ssoadmin_permission_set.rds_query_access,
+    },
+    {
       group          = aws_identitystore_group.forms_production_read_only,
       permission_set = data.aws_ssoadmin_permission_set.aws_read_only_access,
+    },
+    {
+      group          = aws_identitystore_group.forms_production_read_only,
+      permission_set = aws_ssoadmin_permission_set.read_only_billing,
     },
   ]
   # Forms-Staging
@@ -18,6 +26,10 @@ locals {
     {
       group          = aws_identitystore_group.forms_staging_admin,
       permission_set = data.aws_ssoadmin_permission_set.aws_administrator_access,
+    },
+    {
+      group          = aws_identitystore_group.forms_staging_rds_query_access,
+      permission_set = aws_ssoadmin_permission_set.rds_query_access,
     },
     {
       group          = aws_identitystore_group.forms_staging_read_only,

--- a/terragrunt/org_account/iam_identity_center/platform_forms_groups.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_forms_groups.tf
@@ -7,6 +7,12 @@ resource "aws_identitystore_group" "forms_production_admin" {
   identity_store_id = local.sso_identity_store_id
 }
 
+resource "aws_identitystore_group" "forms_production_rds_query_access" {
+  display_name      = "Forms-Production-RDS-Query-Access"
+  description       = "Grants members access to the RDS query editor in the GC Forms Production account."
+  identity_store_id = local.sso_identity_store_id
+}
+
 resource "aws_identitystore_group" "forms_production_read_only" {
   display_name      = "Forms-Production-ReadOnly"
   description       = "Grants members read-only access to the GC Forms Production account."
@@ -19,6 +25,12 @@ resource "aws_identitystore_group" "forms_production_read_only" {
 resource "aws_identitystore_group" "forms_staging_admin" {
   display_name      = "Forms-Staging-Admin"
   description       = "Grants members administrator access to the GC Forms Staging account."
+  identity_store_id = local.sso_identity_store_id
+}
+
+resource "aws_identitystore_group" "forms_staging_rds_query_access" {
+  display_name      = "Forms-Staging-RDS-Query-Access"
+  description       = "Grants members access to the RDS query editor in the GC Forms Staging account."
   identity_store_id = local.sso_identity_store_id
 }
 

--- a/terragrunt/org_account/iam_identity_center/platform_forms_permissions.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_forms_permissions.tf
@@ -1,0 +1,72 @@
+#
+# RDS query editor access
+#
+resource "aws_ssoadmin_permission_set" "rds_query_access" {
+  name         = "RDS-Query-Access"
+  description  = "Grants access to the RDS query editor and Secrets used for authentication."
+  instance_arn = local.sso_instance_arn
+}
+
+resource "aws_ssoadmin_permission_set_inline_policy" "rds_query_access" {
+  permission_set_arn = aws_ssoadmin_permission_set.rds_query_access.arn
+  inline_policy      = data.aws_iam_policy_document.rds_query_access.json
+  instance_arn       = local.sso_instance_arn
+}
+
+data "aws_iam_policy_document" "rds_query_access" {
+
+  statement {
+    sid    = "SecretsDatabaseCredentialsWrite"
+    effect = "Allow"
+    actions = [
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:PutResourcePolicy",
+      "secretsmanager:PutSecretValue",
+      "secretsmanager:DeleteSecret",
+      "secretsmanager:DescribeSecret",
+      "secretsmanager:TagResource"
+    ]
+    resources = [
+      "arn:aws:secretsmanager:*:*:secret:rds-db-credentials/*",
+    ]
+  }
+
+  statement {
+    sid    = "SecretsDatabaseCredentialsRead"
+    effect = "Allow"
+    actions = [
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:DescribeSecret",
+      "secretsmanager:ListSecretVersionIds",
+    ]
+    resources = [
+      "arn:aws:secretsmanager:*:*:secret:database-secret-*"
+    ]
+  }
+
+  statement {
+    sid    = "RDSQueryEditorAccess"
+    effect = "Allow"
+    actions = [
+      "dbqms:CreateFavoriteQuery",
+      "dbqms:CreateQueryHistory",
+      "dbqms:DeleteFavoriteQueries",
+      "dbqms:DeleteQueryHistory",
+      "dbqms:DescribeFavoriteQueries",
+      "dbqms:DescribeQueryHistory",
+      "dbqms:GetQueryString",
+      "dbqms:UpdateFavoriteQuery",
+      "dbqms:UpdateQueryHistory",
+      "rds-data:BatchExecuteStatement",
+      "rds-data:BeginTransaction",
+      "rds-data:CommitTransaction",
+      "rds-data:ExecuteStatement",
+      "rds-data:RollbackTransaction",
+      "secretsmanager:CreateSecret",
+      "secretsmanager:GetRandomPassword",
+      "secretsmanager:ListSecrets",
+      "tag:GetResources",
+    ]
+    resources = ["*"]
+  }
+}


### PR DESCRIPTION
# Summary
Add new Staging/Production groups that allow users access to run RDS queries using the Query Editor.

# Related
- https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/query-editor.html#query-editor.access