### PR TITLE
fix: add missing RDS describe permission

### DIFF
--- a/terragrunt/org_account/iam_identity_center/platform_forms_permissions.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_forms_permissions.tf
@@ -57,6 +57,7 @@ data "aws_iam_policy_document" "rds_query_access" {
       "dbqms:GetQueryString",
       "dbqms:UpdateFavoriteQuery",
       "dbqms:UpdateQueryHistory",
+      "rds:Describe*",
       "rds-data:BatchExecuteStatement",
       "rds-data:BeginTransaction",
       "rds-data:CommitTransaction",


### PR DESCRIPTION
# Summary
Update the RDS query access permission to allow it to describe RDS resources.

# Related
- #267 