### PR TITLE
feat: add scheduled Terraform drift check

### DIFF
--- a/.github/workflows/tf-drift-check.yml
+++ b/.github/workflows/tf-drift-check.yml
@@ -1,6 +1,8 @@
 name: Terraform drift check
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "40 4 * * *" # 4:40 AM UTC  
 
 env:
   AWS_REGION: ca-central-1

--- a/.github/workflows/workflow-failure.yml
+++ b/.github/workflows/workflow-failure.yml
@@ -1,0 +1,19 @@
+name: Workflow failure
+
+on:
+  workflow_run:
+    workflows:
+      - "Terraform drift check"
+      - "Terraform Apply"
+    types:
+      - completed
+
+jobs:
+  on-failure:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'failure'
+    steps:
+      - name: Notify Slack
+        run: |
+          json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":dumpster-fire: `cds-aws-lz` workflow has failed: <${{ github.event.workflow_run.html_url }}|${{ github.event.workflow.name }}>"}}]}'
+          curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.AFT_NOTIFICATIONS_HOOK }}


### PR DESCRIPTION
# Summary
Run a nightly Terraform drift check to make sure the Landing Zone Terraform and resources are in sync.

Add a new workflow that posts to `#internal-sre-alerts` when one of its named workflows fails.
