### PR TITLE
feat: allow update of Pinpoint SMS opt-out lists

### DIFF
--- a/terragrunt/org_account/iam_identity_center/common_permissions.tf
+++ b/terragrunt/org_account/iam_identity_center/common_permissions.tf
@@ -91,6 +91,18 @@ data "aws_iam_policy_document" "admin_support_center" {
     ]
     resources = ["*"]
   }
+
+  statement {
+    sid    = "PinpointListAndDeleteOptedOutNumbers"
+    effect = "Allow"
+    actions = [
+      "sms-voice:DeleteOptedOutNumber",
+      "sms-voice:DescribeOptOutLists",
+      "sms-voice:DescribeOptedOutNumbers",
+      "sms-voice:PutOptedOutNumber"
+    ]
+    resources = ["*"]
+  }
 }
 
 #


### PR DESCRIPTION
# Summary
Update the `SupportCenter-Admin` permission set to allow users to manage the Pinpoint SMS opt-out lists.

This is required as Notify is moving to using Pinpoint to manage SMS.