### PR TITLE
Feat/notify route53 permission set

### DIFF
--- a/terragrunt/org_account/iam_identity_center/platform_notify_assignments.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_notify_assignments.tf
@@ -37,7 +37,7 @@ locals {
       permission_set = data.aws_ssoadmin_permission_set.aws_read_only_access,
     },
     {
-      group          = aws_identitystore_group.notify_production_hosted_zone_record_sets_admin,
+      group          = aws_identitystore_group.notify_production_hosted_zone_admin,
       permission_set = aws_ssoadmin_permission_set.admin_route53_notify_hosted_zone,
     }
   ]

--- a/terragrunt/org_account/iam_identity_center/platform_notify_assignments.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_notify_assignments.tf
@@ -35,6 +35,10 @@ locals {
     {
       group          = aws_identitystore_group.notify_production_read_only,
       permission_set = data.aws_ssoadmin_permission_set.aws_read_only_access,
+    },
+    {
+      group          = aws_identitystore_group.notify_production_hosted_zone_record_sets_admin,
+      permission_set = aws_ssoadmin_permission_set.admin_route53_notify_hosted_zone,
     }
   ]
   # Notification-Staging

--- a/terragrunt/org_account/iam_identity_center/platform_notify_groups.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_notify_groups.tf
@@ -55,8 +55,8 @@ resource "aws_identitystore_group" "notify_production_read_only" {
   identity_store_id = local.sso_identity_store_id
 }
 
-resource "aws_identitystore_group" "notify_production_hosted_zone_record_sets_admin" {
-  display_name      = "Notify-Production-HostedZone-RecordSets-Admin"
+resource "aws_identitystore_group" "notify_production_hosted_zone_admin" {
+  display_name      = "Notify-Production-HostedZone-Admin"
   description       = "Grants members administrator access to the Notify Production account's Route 53 hosted zone record sets."
   identity_store_id = local.sso_identity_store_id
 }

--- a/terragrunt/org_account/iam_identity_center/platform_notify_groups.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_notify_groups.tf
@@ -55,6 +55,12 @@ resource "aws_identitystore_group" "notify_production_read_only" {
   identity_store_id = local.sso_identity_store_id
 }
 
+resource "aws_identitystore_group" "notify_production_hosted_zone_record_sets_admin" {
+  display_name      = "Notify-Production-HostedZone-RecordSets-Admin"
+  description       = "Grants members administrator access to the Notify Production account's Route 53 hosted zone record sets."
+  identity_store_id = local.sso_identity_store_id
+}
+
 #
 # Staging
 #

--- a/terragrunt/org_account/iam_identity_center/platform_notify_permissions.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_notify_permissions.tf
@@ -150,3 +150,45 @@ data "aws_iam_policy_document" "admin_s3_website_assets" {
     ]
   }
 }
+
+#
+#  Route 53
+#
+resource "aws_ssoadmin_permission_set" "admin_route53_notify_hosted_zone" {
+  name = "Route53-NotifyHostedZone-RecordSets-Admin"
+  description = "Grants full access to the Notify hosted zone's record sets in Route 53."
+  instance_arn = local.sso_instance_arn
+}
+
+resource "aws_ssoadmin_permission_set_inline_policy" "admin_route53_notify_hosted_zone" {
+  permission_set_arn = aws_ssoadmin_permission_set.admin_route53_notify_hosted_zone.arn
+  inline_policy = data.aws_iam_policy_document.admin_route53_notify_hosted_zone.json
+  instance_arn = local.sso_instance_arn
+}
+
+data "aws_iam_policy_document" "admin_route53_notify_hosted_zone" {
+  statement {
+    sid    = "ListHostedZones"
+    effect = "Allow"
+    actions = [
+      "route53:GetHostedZone",
+      "route53:ListHostedZones",
+      "route53:GetHostedZoneCount",
+      "route53:ListHostedZonesByName"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid   = "UpdateNotifyHostedZoneRecordSets"
+    effect = "Allow"
+    actions = [
+      "route53:ListResourceRecordSets",
+      "route53:ChangeResourceRecordSets",
+      "route53:GetChange"
+    ]
+    resources = [
+      "arn:aws:route53:::hostedzone/Z1XG153PQF3VV5"
+    ]
+  }
+}

--- a/terragrunt/org_account/iam_identity_center/platform_notify_permissions.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_notify_permissions.tf
@@ -155,15 +155,15 @@ data "aws_iam_policy_document" "admin_s3_website_assets" {
 #  Route 53
 #
 resource "aws_ssoadmin_permission_set" "admin_route53_notify_hosted_zone" {
-  name = "Route53-NotifyHostedZone-RecordSets-Admin"
-  description = "Grants full access to the Notify hosted zone's record sets in Route 53."
+  name         = "Route53-NotifyHostedZone-RecordSets-Admin"
+  description  = "Grants full access to the Notify hosted zone's record sets in Route 53."
   instance_arn = local.sso_instance_arn
 }
 
 resource "aws_ssoadmin_permission_set_inline_policy" "admin_route53_notify_hosted_zone" {
   permission_set_arn = aws_ssoadmin_permission_set.admin_route53_notify_hosted_zone.arn
-  inline_policy = data.aws_iam_policy_document.admin_route53_notify_hosted_zone.json
-  instance_arn = local.sso_instance_arn
+  inline_policy      = data.aws_iam_policy_document.admin_route53_notify_hosted_zone.json
+  instance_arn       = local.sso_instance_arn
 }
 
 data "aws_iam_policy_document" "admin_route53_notify_hosted_zone" {
@@ -180,7 +180,7 @@ data "aws_iam_policy_document" "admin_route53_notify_hosted_zone" {
   }
 
   statement {
-    sid   = "UpdateNotifyHostedZoneRecordSets"
+    sid    = "UpdateNotifyHostedZoneRecordSets"
     effect = "Allow"
     actions = [
       "route53:ListResourceRecordSets",

--- a/terragrunt/org_account/iam_identity_center/platform_notify_permissions.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_notify_permissions.tf
@@ -155,7 +155,7 @@ data "aws_iam_policy_document" "admin_s3_website_assets" {
 #  Route 53
 #
 resource "aws_ssoadmin_permission_set" "admin_route53_notify_hosted_zone" {
-  name         = "Route53-NotifyHostedZone-RecordSets-Admin"
+  name         = "Route53-Notify-Admin"
   description  = "Grants full access to the Notify hosted zone's record sets in Route 53."
   instance_arn = local.sso_instance_arn
 }


### PR DESCRIPTION
# Summary | Résumé

Create admin group, permission set and assignment for the Notify production hosted zone's record sets.