### PR TITLE
feat: allow support center admin to validate phone numbers

### DIFF
--- a/terragrunt/org_account/iam_identity_center/common_permissions.tf
+++ b/terragrunt/org_account/iam_identity_center/common_permissions.tf
@@ -103,6 +103,15 @@ data "aws_iam_policy_document" "admin_support_center" {
     ]
     resources = ["*"]
   }
+
+  statement {
+    sid    = "PinpointPhoneNumberValidate"
+    effect = "Allow"
+    actions = [
+      "mobiletargeting:PhoneNumberValidate"
+    ]
+    resources = ["*"]
+  }
 }
 
 #


### PR DESCRIPTION
# Summary
Update the `SupportCenter-Admin` permission set so that it is able to validate phone numbers in Pinpoint.

# Related
- https://github.com/cds-snc/site-reliability-engineering/issues/1314