### PR TITLE
fix: add missing SupportCenter-Admin permissions

### DIFF
--- a/terragrunt/org_account/iam_identity_center/common_permissions.tf
+++ b/terragrunt/org_account/iam_identity_center/common_permissions.tf
@@ -96,9 +96,13 @@ data "aws_iam_policy_document" "admin_support_center" {
     sid    = "PinpointListAndDeleteOptedOutNumbers"
     effect = "Allow"
     actions = [
+      "sms-voice:GetResourcePolicy",
       "sms-voice:DeleteOptedOutNumber",
+      "sms-voice:DescribePhoneNumbers",
       "sms-voice:DescribeOptOutLists",
       "sms-voice:DescribeOptedOutNumbers",
+      "sms-voice:DescribeRegistrations",
+      "sms-voice:ListTagsForResource",
       "sms-voice:PutOptedOutNumber"
     ]
     resources = ["*"]


### PR DESCRIPTION
# Summary
Update the permissions to allow the opt-out phone number lists to load without errors in the AWS console.

# Related
- Closes https://github.com/cds-snc/site-reliability-engineering/issues/1324