### PR TITLE
fix: format the billing tag extract JSON

### DIFF
--- a/terragrunt/org_account/cost_usage_report/lambdas/billing_extract_tags/main.py
+++ b/terragrunt/org_account/cost_usage_report/lambdas/billing_extract_tags/main.py
@@ -61,9 +61,7 @@ def handler(event, context):
 
     # .write json to string and add a newline between each record
     logging.info("Writing account tags to json")
-    accounts = json.dumps(accounts, default=str)
-    accounts = accounts.replace("}, ", "},\n")
-    accounts = accounts.replace("[{", "[\n{")
+    accounts = json.dumps(accounts, default=str, indent=2)
     logging.info(f"Accounts: {accounts}")
 
     # save accounts to an s3 bucket


### PR DESCRIPTION
# Summary
Update the Lambda function so that the output JSON is formatted.  This is needed to allow the Glue Crawler to properly detected the object fields.

# Related
- https://github.com/cds-snc/platform-core-services/issues/610