### PR TITLE
Reducing Receive wait time for message to 0 to speed up ingestion

### DIFF
--- a/terragrunt/org_account/main/sentinel_cloudtrail.tf
+++ b/terragrunt/org_account/main/sentinel_cloudtrail.tf
@@ -4,7 +4,6 @@ resource "aws_sqs_queue" "cloudtrail_sqs_queue" {
   name                      = "azure-sentinel-cloudtrail-queue"
   max_message_size          = 2048
   message_retention_seconds = 86400
-  receive_wait_time_seconds = 5
   sqs_managed_sse_enabled   = true
 
 }


### PR DESCRIPTION
# Summary | Résumé

Remove the receive_wait_time_seconds attribute for the sqs queue to wait for the message to return before arriving. This might speed up the processing of Sentinel messages. 
