### PR TITLE
Revert "Reducing Receive wait time for message to 0 to speed up ingestion"

### DIFF
--- a/terragrunt/org_account/main/sentinel_cloudtrail.tf
+++ b/terragrunt/org_account/main/sentinel_cloudtrail.tf
@@ -4,6 +4,7 @@ resource "aws_sqs_queue" "cloudtrail_sqs_queue" {
   name                      = "azure-sentinel-cloudtrail-queue"
   max_message_size          = 2048
   message_retention_seconds = 86400
+  receive_wait_time_seconds = 5
   sqs_managed_sse_enabled   = true
 
 }


### PR DESCRIPTION
Reverts cds-snc/cds-aws-lz#326

Reverting because this actually made ingestion delay worse. I did not assume that we have as many empty messages and enable some long polling is to our advantage. 