### PR TITLE
Adding role for the security team to be able generate OSCAL reports

### DIFF
--- a/terragrunt/log_archive/sre_bot/OIDC.tf
+++ b/terragrunt/log_archive/sre_bot/OIDC.tf
@@ -12,7 +12,13 @@ module "OIDC_Roles" {
       name      = local.sre_sechub_automation_rules_oidc_role
       repo_name = "site-reliability-engineering"
       claim     = "ref:refs/heads/main"
+    },
+    {
+      name      = local.security_oscal_report_oidc_role
+      repo_name = "oscal-compliance"
+      claim     = "ref:refs/heads/main"
     }
+
   ]
 
   billing_tag_value = var.billing_code

--- a/terragrunt/log_archive/sre_bot/locals.tf
+++ b/terragrunt/log_archive/sre_bot/locals.tf
@@ -5,4 +5,5 @@ locals {
   }
   sre_sechub_automation_rules_oidc_role = "sre_sechub_automation_rules_github_action"
   sre_vulnerability_report_oidc_role    = "sre_vulnerability_report_github_action"
+  security_oscal_report_oidc_role       = "security_oscal_report_github_action"
 }

--- a/terragrunt/log_archive/sre_bot/security_oscal_report.tf
+++ b/terragrunt/log_archive/sre_bot/security_oscal_report.tf
@@ -1,0 +1,42 @@
+#
+# Role used by the security team to automate config and security hub findings and pull data into a report.
+#
+# It will be assumed by the GitHub Actions workflow.
+#
+
+# Policy document to allow only to get the compliance summary by resource type and list findings 
+data "aws_iam_policy_document" "security_oscal_report" {
+  version = "2012-10-17"
+
+  statement {
+    sid    = "ReadConfig"
+    effect = "Allow"
+    actions = [
+      "config:GetComplianceSummaryByResourceType",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "ReadSecurityHub"
+    effect = "Allow"
+    actions = [
+      "securityhub:GetFindings",
+    ]
+    resources = ["*"]
+  }
+}
+
+# Policy for the role to assume the role
+resource "aws_iam_policy" "security_oscal_report" {
+  name   = "security_oscal_report"
+  policy = data.aws_iam_policy_document.security_oscal_report.json
+
+  tags = local.common_tags
+}
+
+# Attach the policy to the role
+resource "aws_iam_role_policy_attachment" "security_oscal_report" {
+  role       = local.security_oscal_report_oidc_role
+  policy_arn = aws_iam_policy.security_oscal_report.arn
+}


### PR DESCRIPTION
# Summary | Résumé

Adding role for security team to be able to run via a Github action a report to find Config and SecurityHub findings. 
