### PR TITLE
Change permissions of Oscal report role

### DIFF
--- a/terragrunt/log_archive/sre_bot/security_oscal_report.tf
+++ b/terragrunt/log_archive/sre_bot/security_oscal_report.tf
@@ -21,7 +21,7 @@ data "aws_iam_policy_document" "security_oscal_report" {
     sid    = "ReadSecurityHub"
     effect = "Allow"
     actions = [
-      "securityhub:GetFindings",
+      "securityhub:*",
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
# Summary | Résumé

The security team wants to be able to refresh findings, enable more standards and basically have full permissions to Security Hub. It has been approved by the higher ups. 
