### PR TITLE
feat: add account description to sre bot role

### DIFF
--- a/terragrunt/org_account/roles/sre_bot.tf
+++ b/terragrunt/org_account/roles/sre_bot.tf
@@ -23,9 +23,13 @@ data "aws_iam_policy_document" "sre_bot_policy" {
   version = "2012-10-17"
 
   statement {
-    sid       = "ReadOrgAccounts"
-    effect    = "Allow"
-    actions   = ["organizations:ListAccounts"]
+    sid    = "ReadOrgAccounts"
+    effect = "Allow"
+    actions = [
+      "organizations:ListAccounts",
+      "organizations:DescribeAccount",
+      "organizations:ListTagsForResource"
+    ]
     resources = ["*"]
   }
 


### PR DESCRIPTION
# Summary | Résumé

Adding the permission to describe an account and list account tags to the SRE Bot role. Will be leveraged for better AWS spending reporting capabilities.