### PR TITLE
feat: add DataLake-Staging groups

### DIFF
--- a/terragrunt/org_account/iam_identity_center/locals.tf
+++ b/terragrunt/org_account/iam_identity_center/locals.tf
@@ -10,6 +10,7 @@ locals {
   list_manager_production_account_id = "762579868088"
 
   data_lake_production_account_id = "739275439843"
+  data_lake_staging_account_id    = "454671348950"
 
   design_system_production_account_id = "307395567143"
 

--- a/terragrunt/org_account/iam_identity_center/platform_data_lake_assignments.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_data_lake_assignments.tf
@@ -17,8 +17,22 @@ locals {
       permission_set = data.aws_ssoadmin_permission_set.aws_read_only_access,
     }
   ]
+  # DataLake-Staging
+  data_lake_staging_permission_sets = [
+    {
+      group          = aws_identitystore_group.data_lake_staging_admin,
+      permission_set = data.aws_ssoadmin_permission_set.aws_administrator_access,
+    },
+    {
+      group          = aws_identitystore_group.data_lake_staging_read_only_billing,
+      permission_set = aws_ssoadmin_permission_set.read_only_billing,
+    },
+    {
+      group          = aws_identitystore_group.data_lake_staging_read_only,
+      permission_set = data.aws_ssoadmin_permission_set.aws_read_only_access,
+    }
+  ]
 }
-
 
 resource "aws_ssoadmin_account_assignment" "data_lake_production" {
   for_each = { for perm in local.data_lake_production_permission_sets : "${perm.group.display_name}-${perm.permission_set.name}" => perm }
@@ -30,5 +44,18 @@ resource "aws_ssoadmin_account_assignment" "data_lake_production" {
   principal_type = "GROUP"
 
   target_id   = local.data_lake_production_account_id
+  target_type = "AWS_ACCOUNT"
+}
+
+resource "aws_ssoadmin_account_assignment" "data_lake_staging" {
+  for_each = { for perm in local.data_lake_staging_permission_sets : "${perm.group.display_name}-${perm.permission_set.name}" => perm }
+
+  instance_arn       = local.sso_instance_arn
+  permission_set_arn = each.value.permission_set.arn
+
+  principal_id   = each.value.group.group_id
+  principal_type = "GROUP"
+
+  target_id   = local.data_lake_staging_account_id
   target_type = "AWS_ACCOUNT"
 }

--- a/terragrunt/org_account/iam_identity_center/platform_data_lake_groups.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_data_lake_groups.tf
@@ -18,3 +18,24 @@ resource "aws_identitystore_group" "data_lake_production_read_only" {
   description       = "Grants members read-only access to the DataLake Production account."
   identity_store_id = local.sso_identity_store_id
 }
+
+#
+# Staging
+#
+resource "aws_identitystore_group" "data_lake_staging_admin" {
+  display_name      = "DataLake-Staging-Admin"
+  description       = "Grants members administrator access to the DataLake Staging account."
+  identity_store_id = local.sso_identity_store_id
+}
+
+resource "aws_identitystore_group" "data_lake_staging_read_only_billing" {
+  display_name      = "DataLake-Staging-Billing-ReadOnly"
+  description       = "Grants members read-only Billing and Cost Explorer access to the DataLake Staging account."
+  identity_store_id = local.sso_identity_store_id
+}
+
+resource "aws_identitystore_group" "data_lake_staging_read_only" {
+  display_name      = "DataLake-Staging-ReadOnly"
+  description       = "Grants members read-only access to the DataLake Staging account."
+  identity_store_id = local.sso_identity_store_id
+}


### PR DESCRIPTION
# Summary
Add the groups and permission set assignments for the new Data Lake Staging account.

# Related
- https://github.com/cds-snc/site-reliability-engineering/issues/1491