### PR TITLE
chore: remove List Manager permissions

### DIFF
--- a/terragrunt/org_account/iam_identity_center/locals.tf
+++ b/terragrunt/org_account/iam_identity_center/locals.tf
@@ -5,9 +5,8 @@ locals {
   cds_website_production_account_id               = "521732289257"
   cds_website_cms_production_account_id           = "773858180673"
 
-  articles_production_account_id     = "472286471787"
-  articles_staging_account_id        = "729164266357"
-  list_manager_production_account_id = "762579868088"
+  articles_production_account_id = "472286471787"
+  articles_staging_account_id    = "729164266357"
 
   data_lake_production_account_id = "739275439843"
   data_lake_staging_account_id    = "454671348950"

--- a/terragrunt/org_account/iam_identity_center/platform_articles_assignments.tf
+++ b/terragrunt/org_account/iam_identity_center/platform_articles_assignments.tf
@@ -24,17 +24,6 @@ locals {
       permission_set = data.aws_ssoadmin_permission_set.aws_read_only_access,
     },
   ]
-  # PlatformListManager-Production
-  list_manager_production_permission_sets = [
-    {
-      group          = aws_identitystore_group.articles_production_admin,
-      permission_set = data.aws_ssoadmin_permission_set.aws_administrator_access,
-    },
-    {
-      group          = aws_identitystore_group.articles_production_read_only,
-      permission_set = data.aws_ssoadmin_permission_set.aws_read_only_access,
-    },
-  ]
 }
 
 resource "aws_ssoadmin_account_assignment" "articles_production" {
@@ -60,18 +49,5 @@ resource "aws_ssoadmin_account_assignment" "articles_staging" {
   principal_type = "GROUP"
 
   target_id   = local.articles_staging_account_id
-  target_type = "AWS_ACCOUNT"
-}
-
-resource "aws_ssoadmin_account_assignment" "list_manager_production" {
-  for_each = { for perm in local.list_manager_production_permission_sets : "${perm.group.display_name}-${perm.permission_set.name}" => perm }
-
-  instance_arn       = local.sso_instance_arn
-  permission_set_arn = each.value.permission_set.arn
-
-  principal_id   = each.value.group.group_id
-  principal_type = "GROUP"
-
-  target_id   = local.list_manager_production_account_id
   target_type = "AWS_ACCOUNT"
 }


### PR DESCRIPTION
# Summary
Remove the List Manager permissions from the GC Articles group.

# Related
- https://github.com/cds-snc/site-reliability-engineering/issues/1495