### PR TITLE
Adding Cloudformation role needed for SSC CaC deployment

### DIFF
--- a/terragrunt/org_account/roles/cloudformation.tf
+++ b/terragrunt/org_account/roles/cloudformation.tf
@@ -1,0 +1,34 @@
+resource "aws_iam_role" "administration_role" {
+  name = var.cloudformation_administration_role_name
+  path = "/"
+  
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "cloudformation.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+# Inline policy for the administration role
+resource "aws_iam_role_policy" "assume_execution_role_policy" {
+  name = "AssumeRole-AWSCloudFormationStackSetExecutionRole"
+  role = aws_iam_role.administration_role.id
+  
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = "sts:AssumeRole"
+        Resource = "arn:*:iam::*:role/${var.cloudformation_execution_role_name}"
+      }
+    ]
+  })
+}

--- a/terragrunt/org_account/roles/inputs.tf
+++ b/terragrunt/org_account/roles/inputs.tf
@@ -4,3 +4,14 @@ variable "admin_sso_role_arn" {
   sensitive   = true
 }
 
+variable "cloudformation_administration_role_name" {
+  type        = string
+  default     = "AWSCloudFormationStackSetAdministrationRole"
+  description = "The name of the administration role. Defaults to 'AWSCloudFormationStackSetAdministrationRole'."
+}
+
+variable "cloudformation_execution_role_name" {
+  type        = string
+  default     = "AWSCloudFormationStackSetExecutionRole"
+  description = "The name of the execution role that can assume this role. Defaults to 'AWSCloudFormationStackSetExecutionRole'."
+}


### PR DESCRIPTION
# Summary | Résumé

Role needed for SSC CaC deployment to work. Documentation on this role can be found:

1. https://repost.aws/knowledge-center/cfn-iam-best-practices-stackset-resources
2. [aws](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-prereqs-self-managed.html#stacksets-prereqs-accountsetup)

Additional roles might be needed as this is a bit of yakshaving. 