### PR TITLE
Add additional Azure client ID for OIDC role 

### DIFF
--- a/terragrunt/org_account/sentinel_oidc/iam.tf
+++ b/terragrunt/org_account/sentinel_oidc/iam.tf
@@ -8,7 +8,7 @@ resource "aws_iam_role" "sentinel_oidc" {
           Action = "sts:AssumeRoleWithWebIdentity"
           Condition = {
             StringEquals = {
-              "${local.url}:aud" = local.azure_client_id
+              "${local.url}:aud" = [local.azure_client_id, local.azure_client_id_cds_snc_la]
             }
           }
           Effect = "Allow"

--- a/terragrunt/org_account/sentinel_oidc/idp.tf
+++ b/terragrunt/org_account/sentinel_oidc/idp.tf
@@ -1,8 +1,9 @@
 locals {
-  azure_tenet_id  = "221ca1d3-b3f2-4346-8abc-88f802495c7d"
-  azure_client_id = "c8b9cf86-e2b4-4428-b356-14313412a4d1"
-  url             = "sts.windows.net/${local.azure_tenet_id}/"
-  url_https       = "https://${local.url}"
+  azure_tenant_id            = "221ca1d3-b3f2-4346-8abc-88f802495c7d"
+  azure_client_id            = "c8b9cf86-e2b4-4428-b356-14313412a4d1"
+  azure_client_id_cds_snc_la = "50a00e76-8dcf-4c54-b8b1-94f67e340960"
+  url                        = "sts.windows.net/${local.azure_tenant_id}/"
+  url_https                  = "https://${local.url}"
 }
 
 data "tls_certificate" "thumprint" {
@@ -13,6 +14,7 @@ data "tls_certificate" "thumprint" {
 resource "aws_iam_openid_connect_provider" "azure" {
   client_id_list = [
     local.azure_client_id,
+    local.azure_client_id_cds_snc_la,
   ]
   thumbprint_list = [
     data.tls_certificate.thumprint.certificates.0.sha1_fingerprint,


### PR DESCRIPTION
# Summary | Résumé

This PR adds a new clientID for managed identity (cds_snc_function_app_managed_identity) to the oidc role.
resolves #359 
