### PR TITLE
Adding infrastructure to create alerts required by SSC's guardrails checking

### DIFF
--- a/terragrunt/org_account/guardrails_alerting/eventbridge.tf
+++ b/terragrunt/org_account/guardrails_alerting/eventbridge.tf
@@ -1,0 +1,64 @@
+# EventBridge Rule for Cloud Brokering Role Monitoring
+resource "aws_cloudwatch_event_rule" "cloud_brokering_monitoring" {
+  name        = "cloud-brokering-iam-monitoring"
+  description = "Monitor IAM actions performed by Cloud Brokering role"
+  state       = "ENABLED"
+
+  event_pattern = jsonencode({
+    detail = {
+      eventName = [
+        "DeleteRolePolicy",
+        "AttachRolePolicy",
+        "DeleteRole",
+        "DetachRolePolicy",
+        "PutRolePolicy",
+        "UpdateAssumeRolePolicy"
+      ]
+      eventSource = ["iam.amazonaws.com"]
+      userIdentity = {
+        sessionContext = {
+          sessionIssuer = {
+            type = ["Role"]
+            arn  = var.cloud_brokering_role_arn 
+          }
+        }
+      }
+    }
+    detail-type = ["AWS API Call via CloudTrail"]
+    source      = ["aws.iam"]
+  })
+}
+
+# EventBridge Target - SNS Topic
+resource "aws_cloudwatch_event_target" "cloud_brokering_sns_target" {
+  rule      = aws_cloudwatch_event_rule.cloud_brokering_monitoring.name
+  target_id = "CloudBrokeringSNSTarget"
+  arn       = aws_sns_topic.cloud_brokering_alerts.arn
+
+  # Input transformer to format the alert message
+  input_transformer {
+    input_paths = {
+      eventName        = "$.detail.eventName"
+      eventTime        = "$.detail.eventTime"
+      eventId          = "$.detail.eventId"
+      sourceIPAddress  = "$.detail.sourceIPAddress"
+      userArn          = "$.detail.userIdentity.arn"
+      sessionIssuerArn = "$.detail.userIdentity.sessionContext.sessionIssuer.arn"
+      awsRegion        = "$.detail.awsRegion"
+    }
+
+    input_template = jsonencode({
+      alert_type = "CLOUD_BROKERING_SECURITY_EVENT"
+      severity   = "HIGH"
+      event_name = "<eventName>"
+      event_time = "<eventTime>"
+      event_id   = "<eventId>"
+      source_ip  = "<sourceIPAddress>"
+      user_arn   = "<userArn>"
+      role_arn   = "<sessionIssuerArn>"
+      region     = "<awsRegion>"
+      message    = "🚨 SECURITY ALERT: Cloud Brokering role performed IAM action '<eventName>' at <eventTime> from IP <sourceIPAddress>"
+      action_required = "Investigate this activity immediately to ensure it was authorized"
+    })
+  }
+}

--- a/terragrunt/org_account/guardrails_alerting/outputs.tf
+++ b/terragrunt/org_account/guardrails_alerting/outputs.tf
@@ -1,0 +1,24 @@
+output "sns_topic_arn" {
+  description = "ARN of the encrypted SNS topic"
+  value       = aws_sns_topic.cloud_brokering_alerts.arn
+}
+
+output "sns_topic_name" {
+  description = "Name of the SNS topic"
+  value       = aws_sns_topic.cloud_brokering_alerts.name
+}
+
+output "eventbridge_rule_name" {
+  description = "Name of the EventBridge rule"
+  value       = aws_cloudwatch_event_rule.cloud_brokering_monitoring.name
+}
+
+output "eventbridge_rule_arn" {
+  description = "ARN of the EventBridge rule"
+  value       = aws_cloudwatch_event_rule.cloud_brokering_monitoring.arn
+}
+
+output "email_subscription_arn" {
+  description = "ARN of the email subscription (note: will show as pending until confirmed)"
+  value       = aws_sns_topic_subscription.sre_team_email.arn
+}

--- a/terragrunt/org_account/guardrails_alerting/sns.tf
+++ b/terragrunt/org_account/guardrails_alerting/sns.tf
@@ -1,0 +1,94 @@
+data "aws_caller_identity" "current" {}
+
+
+# SNS Topic with AWS Managed KMS Encryption
+resource "aws_sns_topic" "cloud_brokering_alerts" {
+  name = "cloud-brokering-security-alerts"
+
+  # Use AWS managed KMS key for SNS
+  kms_master_key_id = "alias/aws/sns"
+
+  # Additional security settings
+  delivery_policy = jsonencode({
+    "http" = {
+      "defaultHealthyRetryPolicy" = {
+        "minDelayTarget"     = 20
+        "maxDelayTarget"     = 20
+        "numRetries"         = 3
+        "numMaxDelayRetries" = 0
+        "numMinDelayRetries" = 0
+        "numNoDelayRetries"  = 0
+        "backoffFunction"    = "linear"
+      }
+      "disableSubscriptionOverrides" = false
+    }
+  })
+}
+
+# SNS Topic Policy
+resource "aws_sns_topic_policy" "cloud_brokering_alerts" {
+  arn = aws_sns_topic.cloud_brokering_alerts.arn
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+    {
+        Sid    = "AllowEventBridgePublish"
+        Effect = "Allow"
+        Principal = {
+          Service = "events.amazonaws.com"
+        }
+        Action   = "SNS:Publish"
+        Resource = aws_sns_topic.cloud_brokering_alerts.arn
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
+        }
+      },
+      {
+        Sid    = "AccessPolicy"
+        Effect = "Allow"
+        Principal = {
+          AWS = "*"
+        }
+        Action = [
+            "SNS:Publish",
+            "SNS:RemovePermission",
+            "SNS:SetTopicAttributes",
+            "SNS:DeleteTopic",
+            "SNS:ListSubscriptionsByTopic",
+            "SNS:GetTopicAttributes",
+            "SNS:AddPermission",
+            "SNS:Subscribe",
+        ]
+        Resource = aws_sns_topic.cloud_brokering_alerts.arn
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
+        }
+      }
+    ]
+  })
+}
+
+# SNS Email Subscription
+resource "aws_sns_topic_subscription" "sre_team_email" {
+  topic_arn = aws_sns_topic.cloud_brokering_alerts.arn
+  protocol  = "email"
+  endpoint  = var.sre_team_email
+
+  # Optional: Set delivery policy for email
+  delivery_policy = jsonencode({
+    "healthyRetryPolicy" = {
+      "minDelayTarget"     = 20
+      "maxDelayTarget"     = 20
+      "numRetries"         = 3
+      "numMaxDelayRetries" = 0
+      "numMinDelayRetries" = 0
+      "numNoDelayRetries"  = 0
+      "backoffFunction"    = "linear"
+    }
+  })
+}

--- a/terragrunt/org_account/guardrails_alerting/variables.tf
+++ b/terragrunt/org_account/guardrails_alerting/variables.tf
@@ -1,0 +1,21 @@
+
+variable "sre_team_email" {
+  description = "Email address for SRE team alerts"
+  type        = string
+  validation {
+    condition     = can(regex("^[\\w\\.-]+@[\\w\\.-]+\\.[a-zA-Z]{2,}$", var.sre_team_email))
+    error_message = "Please provide a valid email address."
+  }
+  default = "sre-ifs@cds-snc.ca"
+}
+
+
+variable "cloud_brokering_role_arn" {
+  description = "ARN of the Cloud Brokering role to monitor"
+  type        = string
+  default     = "arn:aws:iam::659087519042:role/SSC-CloudBrokering"
+  validation {
+    condition     = can(regex("^arn:aws:iam::[0-9]{12}:role/.+", var.cloud_brokering_role_arn))
+    error_message = "Please provide a valid IAM role ARN."
+  }
+}


### PR DESCRIPTION
# Summary | Résumé

SSC's guardrail 4 checks for any modification of SSC's cloud brokering role and if any change is made, an email alert needs to be sent.

They are just checking for this exact setup so we need to have that setup in order to satisfy that guardrail. 
