### PR TITLE
Fixing the arn to be an array due to apply fail 

### DIFF
--- a/terragrunt/org_account/guardrails_alerting/eventbridge.tf
+++ b/terragrunt/org_account/guardrails_alerting/eventbridge.tf
@@ -19,7 +19,7 @@ resource "aws_cloudwatch_event_rule" "cloud_brokering_monitoring" {
         sessionContext = {
           sessionIssuer = {
             type = ["Role"]
-            arn  = var.cloud_brokering_role_arn
+            arn  = [var.cloud_brokering_role_arn]
           }
         }
       }


### PR DESCRIPTION
# Summary | Résumé

Terraform apply fail due to the reason that the role arn needs to be an array. This PR fixes that. 