### PR TITLE
Attaching SSL policy to cost bucket bucket due to guardrail requirement

### DIFF
--- a/terragrunt/org_account/cost_usage_report/s3.tf
+++ b/terragrunt/org_account/cost_usage_report/s3.tf
@@ -73,11 +73,11 @@ data "aws_iam_policy_document" "cost_usage_report" {
       identifiers = ["*"]
     }
 
-    actions   = ["s3:*"]
+    actions = ["s3:*"]
     resources = [
-        module.cost_usage_report.s3_bucket_arn,
-        "${module.cost_usage_report.s3_bucket_arn}/*"
-      ]
+      module.cost_usage_report.s3_bucket_arn,
+      "${module.cost_usage_report.s3_bucket_arn}/*"
+    ]
     condition {
       test     = "Bool"
       variable = "aws:SecureTransport"


### PR DESCRIPTION
# Summary | Résumé

SSL policy needs to be attached to the cost bucket so that guardrail 7 needs to be satisfied. 