### PR TITLE
fix: set TF backend secondary region to ca-west-1

### DIFF
--- a/terragrunt/org_account/aft/main.tf
+++ b/terragrunt/org_account/aft/main.tf
@@ -10,7 +10,7 @@ module "account_factory_for_terraform" {
   global_customizations_repo_name               = "cds-snc/aft-global-customizations"
 
   ct_home_region              = var.region
-  # tf_backend_secondary_region = "ca-west-1"
+  tf_backend_secondary_region = "us-east-1"
 
   aft_management_account_id = "137554749751"
   audit_account_id          = "886481071419"


### PR DESCRIPTION
# Summary | Résumé

This is intended to migrate the TF backend S3 bucket to the CA West 1 region instead of a US one. Fixes https://github.com/cds-snc/site-reliability-engineering/issues/1602