### PR TITLE
fix: add aft tags for SSC CaC compliance

### DIFF
--- a/terragrunt/org_account/aft/locals.tf
+++ b/terragrunt/org_account/aft/locals.tf
@@ -1,0 +1,5 @@
+locals {
+  aft_tags = {
+    "Data classification" = "Unclassified"
+  }
+}

--- a/terragrunt/org_account/aft/locals.tf
+++ b/terragrunt/org_account/aft/locals.tf
@@ -1,5 +1,5 @@
 locals {
   aft_tags = {
-    "Data classification" = "Unclassified"
+    "Data classification" = "Protected A"
   }
 }

--- a/terragrunt/org_account/aft/main.tf
+++ b/terragrunt/org_account/aft/main.tf
@@ -21,5 +21,6 @@ module "account_factory_for_terraform" {
   aft_feature_delete_default_vpcs_enabled = true
   aft_feature_enterprise_support          = true
   cloudwatch_log_group_retention          = 90
+  tags                                    = local.aft_tags
 
 }


### PR DESCRIPTION
# Summary | Résumé

Add tags for the AFT module based on the data classification provided by SSC