### PR TITLE
Adding GC Signin test groups

### DIFF
--- a/terragrunt/org_account/iam_identity_center/gc_signin_groups.tf
+++ b/terragrunt/org_account/iam_identity_center/gc_signin_groups.tf
@@ -55,3 +55,22 @@ resource "aws_identitystore_group" "gc_signin_dev_read_only_billing" {
   description       = "Grants members read-only Billing and Cost Explorer access to the GC Signin Dev account."
   identity_store_id = local.sso_identity_store_id
 }
+
+# 
+# Test 
+#
+resource "aws_identitystore_group" "gc_signin_test_admin" {
+  display_name      = "GCSignIn-Test-Admin"
+  description       = "Grants members administrator access to the GC Signin Test account."
+  identity_store_id = local.sso_identity_store_id
+}
+resource "aws_identitystore_group" "gc_signin_test_read_only" {
+  display_name      = "GCSignIn-Test-ReadOnly"
+  description       = "Grants members read-only access to the GC Signin Test account."
+  identity_store_id = local.sso_identity_store_id
+}
+resource "aws_identitystore_group" "gc_signin_test_read_only_billing" {
+  display_name      = "GCSignIn-Test-Billing-ReadOnly"
+  description       = "Grants members read-only Billing and Cost Explorer access to the GC Signin Test account."
+  identity_store_id = local.sso_identity_store_id
+}

--- a/terragrunt/org_account/iam_identity_center/locals.tf
+++ b/terragrunt/org_account/iam_identity_center/locals.tf
@@ -18,6 +18,7 @@ locals {
   gc_signin_dev_account_id        = "329599618423"
   gc_signin_production_account_id = "699475931199"
   gc_signin_staging_account_id    = "565393049229"
+  gc_signin_test_account_id       = "768102297819"
 
   digital_transformation_office_production_account_id = "730335533085"
   digital_transformation_office_staging_account_id    = "992382783569"


### PR DESCRIPTION
# Summary | Résumé

Adding GC Signin groups for access to the new GCSignin test account. 