### PR TITLE
Adding a role with organisation:ListAccounts

### DIFF
--- a/terragrunt/org_account/roles/OIDC.tf
+++ b/terragrunt/org_account/roles/OIDC.tf
@@ -19,9 +19,9 @@ module "OIDC_Roles" {
       claim     = "ref:refs/heads/main"
     },
     {
-    name      = local.org_account_list_all_name
-    repo_name = "site-reliability-engineering"
-    claim     = "ref:refs/heads/main"
+      name      = local.org_account_list_all_name
+      repo_name = "site-reliability-engineering"
+      claim     = "ref:refs/heads/main"
     },
   ]
 

--- a/terragrunt/org_account/roles/locals.tf
+++ b/terragrunt/org_account/roles/locals.tf
@@ -4,7 +4,7 @@ locals {
     Terraform  = "true"
   }
   org_account_list_name        = "listAccountsInSandboxOUForNuke" # restricted to sandbox OU
-  org_account_list_all_name        = "listAllAccounts" # list all accounts in the org
+  org_account_list_all_name    = "listAllAccounts"                # list all accounts in the org
   org_allow_policy_toggle      = "ghActionAllowPolicyToggle"
   sre_identity_audit_oidc_role = "sre_identity_audit_oidc_role"
   cbs_central_account_id       = "871282759583"


### PR DESCRIPTION
# Summary | Résumé

Adding a new role with the permission to list accounts across the organization. For use in the angling DNS scanning tool. 