### PR TITLE
feat: add account assignement permission for Bot

### DIFF
--- a/terragrunt/org_account/roles/sre_bot.tf
+++ b/terragrunt/org_account/roles/sre_bot.tf
@@ -65,6 +65,16 @@ data "aws_iam_policy_document" "sre_bot_policy" {
     ]
     resources = ["*"]
   }
+
+  statement {
+    sid    = "ManageSSOAssignments"
+    effect = "Allow"
+    actions = [
+      "sso:ListAccountAssignmentsForPrincipal",
+      "sso:CreateAccountAssignment"
+    ]
+    resources = ["*"]
+  }
 }
 
 resource "aws_iam_policy" "sre_bot_policy" {


### PR DESCRIPTION
# Summary | Résumé

This pull request adds a new permission statement to the SRE bot IAM policy to enable management of AWS SSO account assignments.

**IAM Policy Updates:**

* Added a new statement to the `aws_iam_policy_document.sre_bot_policy` allowing the actions `sso:ListAccountAssignmentsForPrincipal` and `sso:CreateAccountAssignment` on all resources, enabling the SRE bot to manage SSO account assignments.