### PR TITLE
feat: add CloudWatch event rule and target for new account creation

### DIFF
--- a/terragrunt/aft/main/output.tf
+++ b/terragrunt/aft/main/output.tf
@@ -1,0 +1,4 @@
+output "slack_notification_lambda_arn" {
+  value       = module.aft_slack_notification.lambda_arn
+  description = "The ARN of the Lambda function that sends notifications to Slack."
+}

--- a/terragrunt/aft/notifications/aft-notifications.tf
+++ b/terragrunt/aft/notifications/aft-notifications.tf
@@ -17,10 +17,6 @@ data "aws_sns_topic" "aft_failure_notifications" {
   name = "aft-failure-notifications"
 }
 
-data "aws_sns_topic" "aft_notifications" {
-  name = "aft-notifications"
-}
-
 resource "aws_sns_topic_subscription" "aft_failure_notifications" {
   topic_arn = data.aws_sns_topic.aft_failure_notifications.arn
   protocol  = "lambda"
@@ -30,5 +26,5 @@ resource "aws_sns_topic_subscription" "aft_failure_notifications" {
 resource "aws_sns_topic_subscription" "slack_notification" {
   topic_arn = data.aws_sns_topic.aft_notifications.arn
   protocol  = "lambda"
-  endpoint  = module.aft_slack_notification.lambda_arn
+  endpoint  = var.slack_notification_lambda_arn
 }

--- a/terragrunt/aft/notifications/aft-notifications.tf
+++ b/terragrunt/aft/notifications/aft-notifications.tf
@@ -17,6 +17,10 @@ data "aws_sns_topic" "aft_failure_notifications" {
   name = "aft-failure-notifications"
 }
 
+data "aws_sns_topic" "aft_notifications" {
+  name = "aft-notifications"
+}
+
 resource "aws_sns_topic_subscription" "aft_failure_notifications" {
   topic_arn = data.aws_sns_topic.aft_failure_notifications.arn
   protocol  = "lambda"

--- a/terragrunt/aft/notifications/aft-notifications.tf
+++ b/terragrunt/aft/notifications/aft-notifications.tf
@@ -22,3 +22,9 @@ resource "aws_sns_topic_subscription" "aft_failure_notifications" {
   protocol  = "lambda"
   endpoint  = module.aft_failure_notifications.lambda_arn
 }
+
+resource "aws_sns_topic_subscription" "slack_notification" {
+  topic_arn = data.aws_sns_topic.aft_notifications.arn
+  protocol  = "lambda"
+  endpoint  = module.aft_slack_notification.lambda_arn
+}

--- a/terragrunt/aft/notifications/cloudwatch.tf
+++ b/terragrunt/aft/notifications/cloudwatch.tf
@@ -37,3 +37,20 @@ resource "aws_cloudwatch_metric_alarm" "pipeline_failed" {
   alarm_actions     = [aws_sns_topic.aft_cloudwatch_alarms.arn]
   ok_actions        = [aws_sns_topic.aft_cloudwatch_alarms.arn]
 }
+
+resource "aws_cloudwatch_event_rule" "new_account_created" {
+  name        = "new-account-created"
+  description = "Rule to capture new account creation events"
+  event_pattern = jsonencode({
+    "source": ["aws.controltower"],
+    "detail-type": ["AWS Service Event via CloudTrail"],
+    "detail": {
+      "eventName": ["CreateManagedAccount"]
+    }
+  })
+}
+
+resource "aws_cloudwatch_event_target" "send_to_sns" {
+  rule      = aws_cloudwatch_event_rule.new_account_created.name
+  arn       = data.aws_sns_topic.aft_notifications.arn
+}

--- a/terragrunt/aft/notifications/cloudwatch.tf
+++ b/terragrunt/aft/notifications/cloudwatch.tf
@@ -42,15 +42,15 @@ resource "aws_cloudwatch_event_rule" "new_account_created" {
   name        = "new-account-created"
   description = "Rule to capture new account creation events"
   event_pattern = jsonencode({
-    "source": ["aws.controltower"],
-    "detail-type": ["AWS Service Event via CloudTrail"],
-    "detail": {
-      "eventName": ["CreateManagedAccount"]
+    "source" : ["aws.controltower"],
+    "detail-type" : ["AWS Service Event via CloudTrail"],
+    "detail" : {
+      "eventName" : ["CreateManagedAccount"]
     }
   })
 }
 
 resource "aws_cloudwatch_event_target" "send_to_sns" {
-  rule      = aws_cloudwatch_event_rule.new_account_created.name
-  arn       = data.aws_sns_topic.aft_notifications.arn
+  rule = aws_cloudwatch_event_rule.new_account_created.name
+  arn  = data.aws_sns_topic.aft_notifications.arn
 }

--- a/terragrunt/aft/notifications/input.tf
+++ b/terragrunt/aft/notifications/input.tf
@@ -3,3 +3,8 @@ variable "aft_notifications_hook" {
   description = "(Required) The webhook to post AFT Notifications to"
   sensitive   = true
 }
+
+variable "slack_notification_lambda_arn" {
+  type        = string
+  description = "The ARN of the Lambda function for Slack notifications"
+}

--- a/terragrunt/aft/notifications/terragrunt.hcl
+++ b/terragrunt/aft/notifications/terragrunt.hcl
@@ -1,3 +1,12 @@
 include {
   path = find_in_parent_folders()
 }
+
+dependency "aft_main" {
+  config_path = "../main"
+  skip_outputs = true
+}
+
+inputs = {
+  slack_notification_lambda_arn = try(dependency.aft_main.outputs.slack_notification_lambda_arn, "")
+}

--- a/terragrunt/aft/terragrunt.hcl
+++ b/terragrunt/aft/terragrunt.hcl
@@ -15,7 +15,6 @@ inputs = {
   region                        = "ca-central-1"
   billing_code                  = local.cost_center_code
   org_account                   = "659087519042"
-  slack_notification_lambda_arn = dependency.aft_main.outputs.slack_notification_lambda_arn
 }
 
 generate "provider" {

--- a/terragrunt/aft/terragrunt.hcl
+++ b/terragrunt/aft/terragrunt.hcl
@@ -9,12 +9,13 @@ locals {
 # DO NOT CHANGE ANYTHING BELOW HERE UNLESS YOU KNOW WHAT YOU ARE DOING
 
 inputs = {
-  account_id   = local.account_id
-  env          = local.env
-  product_name = local.product_name
-  region       = "ca-central-1"
-  billing_code = local.cost_center_code
-  org_account  = "659087519042"
+  account_id                    = local.account_id
+  env                           = local.env
+  product_name                  = local.product_name
+  region                        = "ca-central-1"
+  billing_code                  = local.cost_center_code
+  org_account                   = "659087519042"
+  slack_notification_lambda_arn = module.aft_slack_notification.lambda_arn
 }
 
 generate "provider" {

--- a/terragrunt/aft/terragrunt.hcl
+++ b/terragrunt/aft/terragrunt.hcl
@@ -15,7 +15,7 @@ inputs = {
   region                        = "ca-central-1"
   billing_code                  = local.cost_center_code
   org_account                   = "659087519042"
-  slack_notification_lambda_arn = module.aft_slack_notification.lambda_arn
+  slack_notification_lambda_arn = dependency.aft_main.outputs.slack_notification_lambda_arn
 }
 
 generate "provider" {


### PR DESCRIPTION
# Summary | Résumé

This pull request introduces new notification capabilities to the AFT (Account Factory for Terraform) system by adding Slack integration and automating notifications for new AWS account creation events. The changes primarily focus on expanding notification channels and improving event-driven automation.

**Notification enhancements:**

* Added a new SNS topic subscription for Slack notifications, enabling Lambda-based delivery of alerts to Slack (`aws_sns_topic_subscription.slack_notification` in `aft-notifications.tf`).

**Event-driven automation:**

* Created a CloudWatch Event Rule to detect new AWS account creation events by monitoring the `CreateManagedAccount` event from AWS Control Tower (`aws_cloudwatch_event_rule.new_account_created` in `cloudwatch.tf`).
* Added a CloudWatch Event Target to send notifications to the SNS topic when a new account is created, integrating with the existing notification workflow (`aws_cloudwatch_event_target.send_to_sns` in `cloudwatch.tf`).