### PR TITLE
feat: add custom GetObject permission for CRA ReadOnly role

### DIFF
--- a/terragrunt/org_account/iam_identity_center/digital_transformation_office_assignments.tf
+++ b/terragrunt/org_account/iam_identity_center/digital_transformation_office_assignments.tf
@@ -43,6 +43,10 @@ locals {
       group          = aws_identitystore_group.cra_dashboard_staging_read_only,
       permission_set = data.aws_ssoadmin_permission_set.aws_read_only_access,
     },
+    {
+      group          = aws_identitystore_group.cra_dashboard_staging_read_only,
+      permission_set = aws_ssoadmin_permission_set.cra_bucket_get_object,
+    }
   ]
 }
 

--- a/terragrunt/org_account/iam_identity_center/digital_transformation_office_permissions.tf
+++ b/terragrunt/org_account/iam_identity_center/digital_transformation_office_permissions.tf
@@ -3,9 +3,9 @@
 #
 
 resource "aws_ssoadmin_permission_set" "cra_bucket_get_object" {
-  name               = "CRABucket-GetObject"
-  description        = "Grants read-only access to the CRA S3 bucket."
-  instance_arn       = local.sso_instance_arn
+  name         = "CRABucket-GetObject"
+  description  = "Grants read-only access to the CRA S3 bucket."
+  instance_arn = local.sso_instance_arn
 }
 
 

--- a/terragrunt/org_account/iam_identity_center/digital_transformation_office_permissions.tf
+++ b/terragrunt/org_account/iam_identity_center/digital_transformation_office_permissions.tf
@@ -1,0 +1,33 @@
+#
+# CRA Bucket GetObject Permissions
+#
+
+resource "aws_ssoadmin_permission_set" "cra_bucket_get_object" {
+  name               = "CRABucket-GetObject"
+  description        = "Grants read-only access to the CRA S3 bucket."
+  instance_arn       = local.sso_instance_arn
+}
+
+
+resource "aws_ssoadmin_permission_set_inline_policy" "cra_bucket_get_object" {
+  permission_set_arn = aws_ssoadmin_permission_set.cra_bucket_get_object.arn
+  inline_policy      = data.aws_iam_policy_document.cra_bucket_get_object.json
+  instance_arn       = local.sso_instance_arn
+}
+
+
+data "aws_iam_policy_document" "cra_bucket_get_object" {
+  statement {
+    sid    = "AllowDataBucketReadAccess"
+    effect = "Allow"
+    actions = [
+      "s3:ListBucket",
+      "s3:GetObject",
+      "s3:GetObjectAcl"
+    ]
+    resources = [
+      "arn:aws:s3:::cra-upd-dashboard-data-staging/*",
+      "arn:aws:s3:::cra-upd-dashboard-data-staging"
+    ]
+  }
+}


### PR DESCRIPTION
# Summary | Résumé

Adding a custom permission set for the CRA ReadOnly group to get objects from their S3 bucket.