### PR TITLE
Changing the tf state bucket secondary region to ca-west-1

### DIFF
--- a/terragrunt/org_account/aft/main.tf
+++ b/terragrunt/org_account/aft/main.tf
@@ -10,7 +10,7 @@ module "account_factory_for_terraform" {
   global_customizations_repo_name               = "cds-snc/aft-global-customizations"
 
   ct_home_region              = var.region
-  tf_backend_secondary_region = "us-east-1"
+  tf_backend_secondary_region = "ca-west-1"
 
   aft_management_account_id = "137554749751"
   audit_account_id          = "886481071419"


### PR DESCRIPTION
# Summary | Résumé

PR Description
Move Terraform secondary backend region to Canada West

**What changed:**
Updated tf_backend_secondary_region from us-east-1 to ca-west-1 in the Account Factory for Terraform (AFT) configuration

**Why**:

- Aligns Terraform backend secondary region with Canadian data residency requirements
- Ensures backup state storage remains within Canadian AWS regions for compliance especially with SSC's CaC