### PR TITLE
fix: update scp to support Bedrock via SRE Tools account

### DIFF
--- a/terragrunt/org_account/organization/scp.tf
+++ b/terragrunt/org_account/organization/scp.tf
@@ -30,7 +30,7 @@ data "aws_iam_policy_document" "cds_snc_universal_guardrails" {
         "493890668711", # Wanpeng Yang scratch 
         "009883649233", # Calvin Rodo scratch 
         "412578375350", # Sylvia McLaughlin scratch 
-        "144414543732",  # DTO Tools AI Staging account
+        "144414543732", # DTO Tools AI Staging account
         "283582579564"  # SRE Tools
       ]
     }
@@ -55,7 +55,7 @@ data "aws_iam_policy_document" "cds_snc_universal_guardrails" {
         "493890668711", # Wanpeng Yang scratch 
         "009883649233", # Calvin Rodo scratch 
         "412578375350", # Sylvia McLaughlin scratch 
-        "144414543732",  # DTO Tools AI Staging account
+        "144414543732", # DTO Tools AI Staging account
         "283582579564"  # SRE Tools
       ]
     }

--- a/terragrunt/org_account/organization/scp.tf
+++ b/terragrunt/org_account/organization/scp.tf
@@ -30,13 +30,9 @@ data "aws_iam_policy_document" "cds_snc_universal_guardrails" {
         "493890668711", # Wanpeng Yang scratch 
         "009883649233", # Calvin Rodo scratch 
         "412578375350", # Sylvia McLaughlin scratch 
-        "144414543732"  # DTO Tools AI Staging account
+        "144414543732",  # DTO Tools AI Staging account
+        "283582579564"  # SRE Tools
       ]
-    }
-    condition {
-      test     = "StringNotEquals"
-      variable = "aws:RequestedRegion"
-      values   = ["ca-central-1"]
     }
   }
 
@@ -50,6 +46,19 @@ data "aws_iam_policy_document" "cds_snc_universal_guardrails" {
     resources = [
       "*",
     ]
+    condition {
+      test     = "StringNotEquals"
+      variable = "aws:PrincipalAccount"
+      values = [
+        "132761243856", # Guillaume Charest scratch
+        "571510889204", # Pat Heard scratch
+        "493890668711", # Wanpeng Yang scratch 
+        "009883649233", # Calvin Rodo scratch 
+        "412578375350", # Sylvia McLaughlin scratch 
+        "144414543732",  # DTO Tools AI Staging account
+        "283582579564"  # SRE Tools
+      ]
+    }
   }
 
   statement {


### PR DESCRIPTION
# Summary | Résumé

This pull request updates the AWS IAM policy document for organization guardrails. The main focus is on refining the policy conditions and adding a new account to the allow list.

Policy condition and account updates:

* Added the `283582579564` (SRE Tools) account to the list of allowed principal accounts in the `NotPrincipal` block.
* Moved the region restriction condition from the `NotPrincipal` block to a new condition block under the `Principal` block, and updated the list of allowed accounts for this new condition.