### PR TITLE
feat: add read permission for savings plans

### DIFF
--- a/terragrunt/org_account/iam_identity_center/common_permissions.tf
+++ b/terragrunt/org_account/iam_identity_center/common_permissions.tf
@@ -40,9 +40,9 @@ data "aws_iam_policy_document" "read_only_billing" {
   }
 
   statement {
-    sid       = "SavingsPlansRead"
-    effect    = "Allow"
-    actions   = [
+    sid    = "SavingsPlansRead"
+    effect = "Allow"
+    actions = [
       "bcm-recommended-actions:ListRecommendedActions"
     ]
     resources = ["*"]

--- a/terragrunt/org_account/iam_identity_center/common_permissions.tf
+++ b/terragrunt/org_account/iam_identity_center/common_permissions.tf
@@ -38,6 +38,15 @@ data "aws_iam_policy_document" "read_only_billing" {
     ]
     resources = ["*"]
   }
+
+  statement {
+    sid       = "SavingsPlansRead"
+    effect    = "Allow"
+    actions   = [
+      "bcm-recommended-actions:ListRecommendedActions"
+    ]
+    resources = ["*"]
+  }
 }
 
 #


### PR DESCRIPTION
# Summary | Résumé

This pull request adds a new permission to the AWS IAM policy document for read-only billing. Specifically, it allows listing recommended actions for AWS Savings Plans, which can help users access cost optimization recommendations.

**Permissions update:**

* Added a new statement to the `aws_iam_policy_document.read_only_billing` policy to allow the `bcm-recommended-actions:ListRecommendedActions` action, enabling users to view Savings Plans recommendations.