### PR TITLE
Adding scratch accounts to allow bedrock for testing

### DIFF
--- a/terragrunt/org_account/organization/scp.tf
+++ b/terragrunt/org_account/organization/scp.tf
@@ -13,7 +13,7 @@ data "aws_iam_policy_document" "cds_snc_universal_guardrails" {
   }
 
   statement {
-    sid    = "DenyBedrock"
+    sid    = "DenyBedrockOutsideWhitelistedAccounts"
     effect = "Deny"
     actions = [
       "bedrock:*"
@@ -21,6 +21,22 @@ data "aws_iam_policy_document" "cds_snc_universal_guardrails" {
     resources = [
       "*",
     ]
+    condition {
+      test     = "StringNotEquals"
+      variable = "aws:PrincipalAccount"
+      values = [
+        "132761243856", # Guillaume Charest scratch
+        "571510889204", # Pat Heard scratch
+        "493890668711", # Wanpeng Yang scratch 
+        "009883649233", # Calvin Rodo scratch 
+        "412578375350", # Sylvia McLaughlin scratch 
+      ]
+    }
+    condition {
+      test     = "StringNotEquals"
+      variable = "aws:RequestedRegion"
+      values   = ["ca-central-1"]
+    }
   }
 
 


### PR DESCRIPTION
# Summary | Résumé

Enabling scratch accounts for SRE folks for AI testing and enablement.
