### PR TITLE
Associating Google Groups for Strategic Data Reporting with AWS account

### DIFF
--- a/terragrunt/org_account/iam_identity_center/locals.tf
+++ b/terragrunt/org_account/iam_identity_center/locals.tf
@@ -38,6 +38,8 @@ locals {
   superset_production_account_id = "066023111852"
   superset_staging_account_id    = "257394494478"
 
+  strategic_data_reporting_production_account_id = "154541629452"
+
   sso_identity_store_id = "d-9d67173bdd"
   sso_instance_id       = "ssoins-8824c710b5ddb452"
   sso_instance_arn      = "arn:aws:sso:::instance/${local.sso_instance_id}"

--- a/terragrunt/org_account/iam_identity_center/strategic_data_reporting_assignments.tf
+++ b/terragrunt/org_account/iam_identity_center/strategic_data_reporting_assignments.tf
@@ -1,0 +1,33 @@
+#
+# Accounts: assign permissions
+#
+locals {
+  # Strategic Data and Reporting - Production
+  strategic_data_reporting_production_permission_sets = [
+    {
+      group          = aws_identitystore_group.strategic_data_reporting_production_admin,
+      permission_set = data.aws_ssoadmin_permission_set.aws_administrator_access,
+    },
+    {
+      group          = aws_identitystore_group.strategic_data_reporting_production_billing_read_only,
+      permission_set = aws_ssoadmin_permission_set.read_only_billing,
+    },
+    {
+      group          = aws_identitystore_group.strategic_data_reporting_production_read_only,
+      permission_set = data.aws_ssoadmin_permission_set.aws_read_only_access,
+    },
+  ]
+}
+
+resource "aws_ssoadmin_account_assignment" "strategic_data_reporting_production" {
+  for_each = { for perm in local.strategic_data_reporting_production_permission_sets : "${perm.group.display_name}-${perm.permission_set.name}" => perm }
+
+  instance_arn       = local.sso_instance_arn
+  permission_set_arn = each.value.permission_set.arn
+
+  principal_id   = each.value.group.group_id
+  principal_type = "GROUP"
+
+  target_id   = local.strategic_data_reporting_production_account_id
+  target_type = "AWS_ACCOUNT"
+}

--- a/terragrunt/org_account/iam_identity_center/strategic_data_reporting_groups.tf
+++ b/terragrunt/org_account/iam_identity_center/strategic_data_reporting_groups.tf
@@ -1,0 +1,20 @@
+#
+# Strategic Data and Reporting
+#
+resource "aws_identitystore_group" "strategic_data_reporting_production_admin" {
+  display_name      = "StrategicDataReporting-Production-Admin"
+  description       = "Grants members administrator access to the Strategic Data and Reporting Production account."
+  identity_store_id = local.sso_identity_store_id
+}
+
+resource "aws_identitystore_group" "strategic_data_reporting_production_billing_read_only" {
+  display_name      = "StrategicDataReporting-Production-Billing-ReadOnly"
+  description       = "Grants members read-only Billing and Cost Explorer access to the Strategic Data and Reporting Production account."
+  identity_store_id = local.sso_identity_store_id
+}
+
+resource "aws_identitystore_group" "strategic_data_reporting_production_read_only" {
+  display_name      = "StrategicDataReporting-Production-ReadOnly"
+  description       = "Grants members read-only access to the Strategic Data and Reporting Production account."
+  identity_store_id = local.sso_identity_store_id
+}


### PR DESCRIPTION
# Summary | Résumé

Creating the Google Group associations with the Strategic Data and Reporting account. 