### PR TITLE
Adding CanadaLogin Data groups

### DIFF
--- a/terragrunt/org_account/iam_identity_center/gc_signin_assignments.tf
+++ b/terragrunt/org_account/iam_identity_center/gc_signin_assignments.tf
@@ -76,6 +76,21 @@ locals {
       permission_set = data.aws_ssoadmin_permission_set.aws_read_only_access,
     }
   ]
+  # CanadaLogin-Data Production
+  canada_login_data_production_permission_sets = [
+    {
+      group          = aws_identitystore_group.canada_login_data_production_admin,
+      permission_set = data.aws_ssoadmin_permission_set.aws_administrator_access,
+    },
+    {
+      group          = aws_identitystore_group.canada_login_data_production_read_only_billing,
+      permission_set = aws_ssoadmin_permission_set.read_only_billing,
+    },
+    {
+      group          = aws_identitystore_group.canada_login_data_production_read_only,
+      permission_set = data.aws_ssoadmin_permission_set.aws_read_only_access,
+    }
+  ]
 }
 
 resource "aws_ssoadmin_account_assignment" "gc_signin_production" {
@@ -140,5 +155,18 @@ resource "aws_ssoadmin_account_assignment" "gc_signin_test" {
   principal_type = "GROUP"
 
   target_id   = local.gc_signin_test_account_id
+  target_type = "AWS_ACCOUNT"
+}
+
+resource "aws_ssoadmin_account_assignment" "canada_login_data_production" {
+  for_each = { for perm in local.canada_login_data_production_permission_sets : "${perm.group.display_name}-${perm.permission_set.name}" => perm }
+
+  instance_arn       = local.sso_instance_arn
+  permission_set_arn = each.value.permission_set.arn
+
+  principal_id   = each.value.group.group_id
+  principal_type = "GROUP"
+
+  target_id   = local.canada_login_data_production_account_id
   target_type = "AWS_ACCOUNT"
 }

--- a/terragrunt/org_account/iam_identity_center/gc_signin_groups.tf
+++ b/terragrunt/org_account/iam_identity_center/gc_signin_groups.tf
@@ -93,3 +93,22 @@ resource "aws_identitystore_group" "gc_signin_test_read_only_billing" {
   description       = "Grants members read-only Billing and Cost Explorer access to the GC Signin Test account."
   identity_store_id = local.sso_identity_store_id
 }
+
+#
+# CanadaLogin-Data Production
+#
+resource "aws_identitystore_group" "canada_login_data_production_admin" {
+  display_name      = "CanadaLoginData-Production-Admin"
+  description       = "Grants members administrator access to the CanadaLogin-Data Production account."
+  identity_store_id = local.sso_identity_store_id
+}
+resource "aws_identitystore_group" "canada_login_data_production_read_only" {
+  display_name      = "CanadaLoginData-Production-ReadOnly"
+  description       = "Grants members read-only access to the CanadaLogin-Data Production account."
+  identity_store_id = local.sso_identity_store_id
+}
+resource "aws_identitystore_group" "canada_login_data_production_read_only_billing" {
+  display_name      = "CanadaLoginData-Production-Billing-ReadOnly"
+  description       = "Grants members read-only Billing and Cost Explorer access to the CanadaLogin-Data Production account."
+  identity_store_id = local.sso_identity_store_id
+}

--- a/terragrunt/org_account/iam_identity_center/gc_signin_groups.tf
+++ b/terragrunt/org_account/iam_identity_center/gc_signin_groups.tf
@@ -95,7 +95,7 @@ resource "aws_identitystore_group" "gc_signin_test_read_only_billing" {
 }
 
 #
-# CanadaLogin-Data Production
+# CanadaLogin-Data Account 
 #
 resource "aws_identitystore_group" "canada_login_data_production_admin" {
   display_name      = "CanadaLoginData-Production-Admin"

--- a/terragrunt/org_account/iam_identity_center/locals.tf
+++ b/terragrunt/org_account/iam_identity_center/locals.tf
@@ -21,6 +21,8 @@ locals {
   gc_signin_test_account_id       = "768102297819"
   gc_signin_dev2_account_id       = "780097021060"
 
+  canada_login_data_production_account_id = "029422952198"
+
   digital_transformation_office_production_account_id = "730335533085"
   digital_transformation_office_staging_account_id    = "992382783569"
   digital_transformation_office_ai_staging_account_id = "144414543732"


### PR DESCRIPTION
# Summary | Résumé

Adding Canada Login Data groups to create the Google groups and AWS associations. 
