### PR TITLE
Enabling tag policy for AWS Organizations

### DIFF
--- a/terragrunt/org_account/organization/organizations.tf
+++ b/terragrunt/org_account/organization/organizations.tf
@@ -15,7 +15,8 @@ resource "aws_organizations_organization" "org_config" {
   ]
 
   enabled_policy_types = [
-    "SERVICE_CONTROL_POLICY"
+    "SERVICE_CONTROL_POLICY",
+    "TAG_POLICY"
   ]
 
   feature_set = "ALL"


### PR DESCRIPTION
# Summary | Résumé

Enabling a new policy Tag policy so that we can enforce tags on resources. This AWS article/blog explains it in more details - https://aws.amazon.com/blogs/aws-cloud-financial-management/gs-create-and-enforce-your-tagging-strategy-for-more-granular-cost-visibility/
