### PR TITLE
Adding exception so that Forms production account can delete access analyzer

### DIFF
--- a/terragrunt/org_account/organization/scp.tf
+++ b/terragrunt/org_account/organization/scp.tf
@@ -114,6 +114,11 @@ data "aws_iam_policy_document" "cds_snc_universal_guardrails" {
     resources = [
       "*"
     ]
+    condition {
+      test     = "StringNotEquals"
+      variable = "aws:PrincipalAccount"
+      values   = ["957818836222"]
+    }
   }
 
   statement {


### PR DESCRIPTION
# Summary | Résumé

This policy will be reverted once the deletion takes place. Forms production wants to delete the access analyzer resource. 