### PR TITLE
Revert "Adding exception so that Forms production account can delete access analyzer"

### DIFF
--- a/terragrunt/org_account/organization/scp.tf
+++ b/terragrunt/org_account/organization/scp.tf
@@ -114,11 +114,6 @@ data "aws_iam_policy_document" "cds_snc_universal_guardrails" {
     resources = [
       "*"
     ]
-    condition {
-      test     = "StringNotEquals"
-      variable = "aws:PrincipalAccount"
-      values   = ["957818836222"]
-    }
   }
 
   statement {


### PR DESCRIPTION
# Summary
The access analyzer has been deleted so this change can be reverted.

Reverts cds-snc/cds-aws-lz#409