### PR TITLE
Add AWS Config rules and aggregator for ssc_cbrid tag compliance

### DIFF
--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -96,6 +96,11 @@ jobs:
             module: main
             account: 886481071419
             role: cds-aws-lz-apply
+          
+          - account_folder: audit
+            module: config
+            account: 886481071419
+            role: cds-aws-lz-apply
 
           - account_folder: audit
             module: sre_bot

--- a/.github/workflows/tf-drift-check.yml
+++ b/.github/workflows/tf-drift-check.yml
@@ -78,6 +78,11 @@ jobs:
             role: cds-aws-lz-plan
 
           - account_folder: audit
+            module: config
+            account: 886481071419
+            role: cds-aws-lz-plan
+
+          - account_folder: audit
             module: sre_bot
             account: 886481071419
             role: cds-aws-lz-plan

--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -93,6 +93,11 @@ jobs:
             role: cds-aws-lz-plan
 
           - account_folder: audit
+            module: config 
+            account: 886481071419
+            role: cds-aws-lz-plan
+
+          - account_folder: audit
             module: sre_bot
             account: 886481071419
             role: cds-aws-lz-plan

--- a/terragrunt/audit/config/.terraform.lock.hcl
+++ b/terragrunt/audit/config/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.84.0"
+  constraints = "<= 5.84.0"
+  hashes = [
+    "h1:OJ53RNte7HLHSMxSkzu1S6H8sC0T8qnCAOcNLjjtMpc=",
+    "zh:078f77438aba6ec8bf9154b7d223e5c71c48d805d6cd3bcf9db0cc1e82668ac3",
+    "zh:1f6591ff96be00501e71b792ed3a5a14b21ff03afec9a1c4a3fd9300e6e5b674",
+    "zh:2ab694e022e81dd74485351c5836148a842ed71cf640664c9d871cb517b09602",
+    "zh:33c8ccb6e3dc496e828a7572dd981366c6271075c1189f249b9b5236361d7eff",
+    "zh:6f31068ebad1d627e421c72ccdaafe678c53600ca73714e977bf45ff43ae5d17",
+    "zh:7488623dccfb639347cae66f9001d39cf06b92e8081975235a1ac3a0ac3f44aa",
+    "zh:7f042b78b9690a8725c95b91a70fc8e264011b836605bcc342ac297b9ea3937d",
+    "zh:88b56ac6c7209dc0a775b79975a371918f3aed8f015c37d5899f31deff37c61a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a1979ba840d704af0932f8de5f541cbb4caa9b6bbd25ed552a24e6772175ba07",
+    "zh:b058c0533dae580e69d1adbc1f69e6a80632374abfc10e8634d06187a108e87b",
+    "zh:c88610af9cf957f8dcf4382e0c9ca566ef10e3290f5de01d4d90b2d81b078aa8",
+    "zh:e9562c055a2247d0c287772b55abef468c79f8d66a74780fe1c5e5dae1a284a9",
+    "zh:f7a7c71d28441d925a25c08c4485c015b2d9f0338bc9707443e91ff8e161d3d9",
+    "zh:fee533e81976d0900aa6fa443dc54ef171cbd901847f28a6e8edb1d161fa6fde",
+  ]
+}

--- a/terragrunt/audit/config/Makefile
+++ b/terragrunt/audit/config/Makefile
@@ -1,0 +1,7 @@
+.PHONY: fmt docs
+
+fmt:
+	@terraform fmt -recursive
+
+docs:
+	@terraform-docs markdown -c ../../.terraform-docs.yml . > README.md

--- a/terragrunt/audit/config/README.md
+++ b/terragrunt/audit/config/README.md
@@ -1,0 +1,39 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | <= 5.84.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.84.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_config_configuration_aggregator.organization](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_configuration_aggregator) | resource |
+| [aws_config_organization_managed_rule.require_ssc_cbrid](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_organization_managed_rule) | resource |
+| [aws_iam_role.config_aggregator](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.config_aggregator](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_account_id"></a> [account\_id](#input\_account\_id) | (Required) The account ID to perform actions on. | `string` | n/a | yes |
+| <a name="input_billing_code"></a> [billing\_code](#input\_billing\_code) | The billing code to tag our resources with | `string` | n/a | yes |
+| <a name="input_env"></a> [env](#input\_env) | The current running environment | `string` | n/a | yes |
+| <a name="input_org_account"></a> [org\_account](#input\_org\_account) | The account ID of the main organization account | `any` | n/a | yes |
+| <a name="input_product_name"></a> [product\_name](#input\_product\_name) | (Required) The name of the product you are deploying. | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | The current AWS region | `string` | n/a | yes |
+
+## Outputs
+
+No outputs.

--- a/terragrunt/audit/config/aggregator.tf
+++ b/terragrunt/audit/config/aggregator.tf
@@ -1,0 +1,29 @@
+# Aggregate AWS Config data from all accounts and regions in the organization
+resource "aws_config_configuration_aggregator" "organization" {
+  name = "cds-cbr-tags-aggregator"
+
+  organization_aggregation_source {
+    regions  = ["ca-central-1", "us-east-1"]
+    role_arn = aws_iam_role.config_aggregator.arn
+  }
+}
+
+# IAM role assumed by AWS Config to collect data across the organization
+resource "aws_iam_role" "config_aggregator" {
+  name = "AWSConfigRoleForOrganizations"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "config.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+# Attach the AWS managed policy for organization-wide Config access
+resource "aws_iam_role_policy_attachment" "config_aggregator" {
+  role       = aws_iam_role.config_aggregator.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSConfigRoleForOrganizations"
+}

--- a/terragrunt/audit/config/config_rules.tf
+++ b/terragrunt/audit/config/config_rules.tf
@@ -1,0 +1,20 @@
+# Config rule auditing all resources to determine ssc_cbrid tag compliancy.
+
+# Organization-wide managed rule enforcing approved ssc_cbrid tag values
+resource "aws_config_organization_managed_rule" "require_ssc_cbrid" {
+  name            = "require-ssc-cbrid-tag"
+  description     = "Requires the ssc_cbrid tag with an approved value on all resources"
+  rule_identifier = "REQUIRED_TAGS"
+
+  # Approved CBR IDs for the ssc_cbrid tag
+  input_parameters = jsonencode({
+    tag1Key   = "ssc_cbrid"
+    tag1Value = "22DH,22DI,21JC,22DJ" # Only allow those values for the cbr ids. Comma-separated allowed values
+  })
+
+  # Scope to specific resource types; empty means all supported types
+  resource_types_scope = []
+
+  # Accounts excluded from this rule (e.g., sandbox or test accounts)
+  excluded_accounts = []
+}

--- a/terragrunt/audit/config/locals.tf
+++ b/terragrunt/audit/config/locals.tf
@@ -1,0 +1,6 @@
+locals {
+  common_tags = {
+    CostCentre = var.billing_code
+    Terraform  = "true"
+  }
+}

--- a/terragrunt/audit/config/terragrunt.hcl
+++ b/terragrunt/audit/config/terragrunt.hcl
@@ -1,0 +1,3 @@
+include {
+  path = find_in_parent_folders()
+}


### PR DESCRIPTION
# Summary | Résumé

Add AWS Config rules and aggregator for ssc_cbrid tag compliance:

- Sets up AWS Config in the audit account (886481071419) to enforce ssc_cbrid tag compliance across the organization.
- Adds an organization-wide Config aggregator scoped to ca-central-1 and us-east-1 with the required IAM role and policy
- Adds a REQUIRED_TAGS managed rule to validate that resources have an ssc_cbrid tag with an approved CBR ID (22DH, 22DI, 21JC, 22DJ)
