### PR TITLE
SSC CBR tags compliance report

### DIFF
--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -147,5 +147,6 @@ jobs:
           TF_VAR_weekly_spend_notifier_hook: ${{ secrets[matrix.weekly_spend_notifier_hook]}}
           TF_VAR_aft_notifications_hook: ${{ secrets[matrix.aft_notifications_hook]}}
           TF_VAR_admin_sso_role_arn: ${{ secrets[matrix.admin_sso_role_arn] }}
+          TF_VAR_SLACK_WEBHOOK_URL: ${{ secrets[matrix.spend_notifier_hook] }}
         run: |
           terragrunt apply --terragrunt-non-interactive -auto-approve

--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -148,6 +148,6 @@ jobs:
           TF_VAR_weekly_spend_notifier_hook: ${{ secrets[matrix.weekly_spend_notifier_hook]}}
           TF_VAR_aft_notifications_hook: ${{ secrets[matrix.aft_notifications_hook]}}
           TF_VAR_admin_sso_role_arn: ${{ secrets[matrix.admin_sso_role_arn] }}
-          TF_VAR_slack_webhook_url: ${{ secrets[matrix.slack_webhook_url] }}
+          TF_VAR_slack_webhook_url: ${{ matrix.slack_webhook_url && secrets[matrix.slack_webhook_url] }}
         run: |
           terragrunt apply --terragrunt-non-interactive -auto-approve

--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -101,6 +101,7 @@ jobs:
             module: config
             account: 886481071419
             role: cds-aws-lz-apply
+            slack_webhook_url: SPEND_NOTIFIER_HOOK 
 
           - account_folder: audit
             module: sre_bot

--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -148,6 +148,6 @@ jobs:
           TF_VAR_weekly_spend_notifier_hook: ${{ secrets[matrix.weekly_spend_notifier_hook]}}
           TF_VAR_aft_notifications_hook: ${{ secrets[matrix.aft_notifications_hook]}}
           TF_VAR_admin_sso_role_arn: ${{ secrets[matrix.admin_sso_role_arn] }}
-          TF_VAR_SLACK_WEBHOOK_URL: ${{ secrets[matrix.spend_notifier_hook] }}
+          TF_VAR_slack_webhook_url: ${{ secrets[matrix.slack_webhook_url] }}
         run: |
           terragrunt apply --terragrunt-non-interactive -auto-approve

--- a/.github/workflows/tf-drift-check.yml
+++ b/.github/workflows/tf-drift-check.yml
@@ -126,6 +126,7 @@ jobs:
           TF_VAR_weekly_spend_notifier_hook: ${{ secrets[matrix.weekly_spend_notifier_hook]}}
           TF_VAR_aft_notifications_hook: ${{ secrets[matrix.aft_notifications_hook]}}
           TF_VAR_admin_sso_role_arn: ${{ secrets[matrix.admin_sso_role_arn] }}
+          TF_VAR_SLACK_WEBHOOK_URL: ${{ secrets[matrix.spend_notifier_hook] }}
         working-directory: ./terragrunt/${{ matrix.account_folder }}/${{ matrix.module }}
         run: |
           terragrunt init

--- a/.github/workflows/tf-drift-check.yml
+++ b/.github/workflows/tf-drift-check.yml
@@ -127,7 +127,7 @@ jobs:
           TF_VAR_weekly_spend_notifier_hook: ${{ secrets[matrix.weekly_spend_notifier_hook]}}
           TF_VAR_aft_notifications_hook: ${{ secrets[matrix.aft_notifications_hook]}}
           TF_VAR_admin_sso_role_arn: ${{ secrets[matrix.admin_sso_role_arn] }}
-          TF_VAR_slack_webhook_url: ${{ secrets[matrix.slack_webhook_url] }}
+          TF_VAR_slack_webhook_url: ${{ matrix.slack_webhook_url && secrets[matrix.slack_webhook_url] }}
         working-directory: ./terragrunt/${{ matrix.account_folder }}/${{ matrix.module }}
         run: |
           terragrunt init

--- a/.github/workflows/tf-drift-check.yml
+++ b/.github/workflows/tf-drift-check.yml
@@ -81,6 +81,7 @@ jobs:
             module: config
             account: 886481071419
             role: cds-aws-lz-plan
+            slack_webhook_url: SPEND_NOTIFIER_HOOK 
 
           - account_folder: audit
             module: sre_bot

--- a/.github/workflows/tf-drift-check.yml
+++ b/.github/workflows/tf-drift-check.yml
@@ -127,7 +127,7 @@ jobs:
           TF_VAR_weekly_spend_notifier_hook: ${{ secrets[matrix.weekly_spend_notifier_hook]}}
           TF_VAR_aft_notifications_hook: ${{ secrets[matrix.aft_notifications_hook]}}
           TF_VAR_admin_sso_role_arn: ${{ secrets[matrix.admin_sso_role_arn] }}
-          TF_VAR_SLACK_WEBHOOK_URL: ${{ secrets[matrix.spend_notifier_hook] }}
+          TF_VAR_slack_webhook_url: ${{ secrets[matrix.slack_webhook_url] }}
         working-directory: ./terragrunt/${{ matrix.account_folder }}/${{ matrix.module }}
         run: |
           terragrunt init

--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -147,6 +147,6 @@ jobs:
         with:
           comment-delete: true
           comment-title: Plan for ${{matrix.account_folder}}/${{ matrix.module }}
-          dir ectory: ./terragrunt/${{ matrix.account_folder }}/${{ matrix.module }}
+          directory: ./terragrunt/${{ matrix.account_folder }}/${{ matrix.module }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           terragrunt: true

--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -96,6 +96,7 @@ jobs:
             module: config 
             account: 886481071419
             role: cds-aws-lz-plan
+            slack_webhook_url: SPEND_NOTIFIER_HOOK 
 
           - account_folder: audit
             module: sre_bot

--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -141,10 +141,12 @@ jobs:
           TF_VAR_weekly_spend_notifier_hook: ${{ secrets[matrix.weekly_spend_notifier_hook]}}
           TF_VAR_aft_notifications_hook: ${{ secrets[matrix.aft_notifications_hook]}}
           TF_VAR_admin_sso_role_arn: ${{ secrets[matrix.admin_sso_role_arn] }}
+          TF_VAR_SLACK_WEBHOOK_URL: ${{ secrets[matrix.spend_notifier_hook] }}
+          
         uses: cds-snc/terraform-plan@v3
         with:
           comment-delete: true
           comment-title: Plan for ${{matrix.account_folder}}/${{ matrix.module }}
-          directory: ./terragrunt/${{ matrix.account_folder }}/${{ matrix.module }}
+          dir ectory: ./terragrunt/${{ matrix.account_folder }}/${{ matrix.module }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           terragrunt: true

--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -96,7 +96,6 @@ jobs:
             module: config 
             account: 886481071419
             role: cds-aws-lz-plan
-            slack_webhook_url: SPEND_NOTIFIER_HOOK 
 
           - account_folder: audit
             module: sre_bot

--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -93,9 +93,10 @@ jobs:
             role: cds-aws-lz-plan
 
           - account_folder: audit
-            module: config 
+            module: config
             account: 886481071419
             role: cds-aws-lz-plan
+            slack_webhook_url: SPEND_NOTIFIER_HOOK
 
           - account_folder: audit
             module: sre_bot
@@ -141,7 +142,7 @@ jobs:
           TF_VAR_weekly_spend_notifier_hook: ${{ secrets[matrix.weekly_spend_notifier_hook]}}
           TF_VAR_aft_notifications_hook: ${{ secrets[matrix.aft_notifications_hook]}}
           TF_VAR_admin_sso_role_arn: ${{ secrets[matrix.admin_sso_role_arn] }}
-          TF_VAR_SLACK_WEBHOOK_URL: ${{ secrets[matrix.spend_notifier_hook] }}
+          TF_VAR_slack_webhook_url: ${{ matrix.slack_webhook_url && secrets[matrix.slack_webhook_url] }}
           
         uses: cds-snc/terraform-plan@v3
         with:

--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -142,7 +142,7 @@ jobs:
           TF_VAR_weekly_spend_notifier_hook: ${{ secrets[matrix.weekly_spend_notifier_hook]}}
           TF_VAR_aft_notifications_hook: ${{ secrets[matrix.aft_notifications_hook]}}
           TF_VAR_admin_sso_role_arn: ${{ secrets[matrix.admin_sso_role_arn] }}
-          TF_VAR_slack_webhook_url: ${{ secrets[matrix.slack_webhook_url] }}
+          TF_VAR_slack_webhook_url: ${{ matrix.slack_webhook_url && secrets[matrix.slack_webhook_url] }}
           
         uses: cds-snc/terraform-plan@v3
         with:

--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -142,7 +142,7 @@ jobs:
           TF_VAR_weekly_spend_notifier_hook: ${{ secrets[matrix.weekly_spend_notifier_hook]}}
           TF_VAR_aft_notifications_hook: ${{ secrets[matrix.aft_notifications_hook]}}
           TF_VAR_admin_sso_role_arn: ${{ secrets[matrix.admin_sso_role_arn] }}
-          TF_VAR_slack_webhook_url: ${{ matrix.slack_webhook_url && secrets[matrix.slack_webhook_url] }}
+          TF_VAR_slack_webhook_url: ${{ secrets[matrix.slack_webhook_url] }}
           
         uses: cds-snc/terraform-plan@v3
         with:

--- a/terragrunt/audit/config/README.md
+++ b/terragrunt/audit/config/README.md
@@ -12,7 +12,10 @@
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_compliance_report"></a> [compliance\_report](#module\_compliance\_report) | github.com/cds-snc/terraform-modules//lambda_schedule | v11.3.0 |
+| <a name="module_report_bucket"></a> [report\_bucket](#module\_report\_bucket) | github.com/cds-snc/terraform-modules//S3 | v11.3.0 |
 
 ## Resources
 
@@ -21,7 +24,10 @@ No modules.
 | [aws_config_configuration_aggregator.organization](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_configuration_aggregator) | resource |
 | [aws_config_organization_managed_rule.require_ssc_cbrid](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_organization_managed_rule) | resource |
 | [aws_iam_role.config_aggregator](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.report](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.report](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy_attachment.config_aggregator](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_policy_document.report](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
@@ -29,10 +35,17 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_account_id"></a> [account\_id](#input\_account\_id) | (Required) The account ID to perform actions on. | `string` | n/a | yes |
 | <a name="input_billing_code"></a> [billing\_code](#input\_billing\_code) | The billing code to tag our resources with | `string` | n/a | yes |
+| <a name="input_config_rule_name"></a> [config\_rule\_name](#input\_config\_rule\_name) | The Config rule to inspect. | `string` | `"OrgConfigRule-require-ssc-cbrid-tag-wf6xls0p"` | no |
 | <a name="input_env"></a> [env](#input\_env) | The current running environment | `string` | n/a | yes |
+| <a name="input_lambda_image_tag"></a> [lambda\_image\_tag](#input\_lambda\_image\_tag) | ECR image tag the Lambda runs. Bump when you push a new image. | `string` | `"latest"` | no |
 | <a name="input_org_account"></a> [org\_account](#input\_org\_account) | The account ID of the main organization account | `any` | n/a | yes |
 | <a name="input_product_name"></a> [product\_name](#input\_product\_name) | (Required) The name of the product you are deploying. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The current AWS region | `string` | n/a | yes |
+| <a name="input_report_prefix"></a> [report\_prefix](#input\_report\_prefix) | S3 key prefix under which CSV reports are written. | `string` | `"config-compliance-reports"` | no |
+| <a name="input_report_retention_days"></a> [report\_retention\_days](#input\_report\_retention\_days) | Days to retain report objects before automatic deletion. | `number` | `90` | no |
+| <a name="input_schedule_expression"></a> [schedule\_expression](#input\_schedule\_expression) | EventBridge schedule expression in UTC. Empty string disables scheduling. | `string` | `"cron(0 6 ? * MON *)"` | no |
+| <a name="input_slack_webhook_url"></a> [slack\_webhook\_url](#input\_slack\_webhook\_url) | Incoming webhook URL for the SRE bot / Slack. | `string` | n/a | yes |
+| <a name="input_top_n_accounts"></a> [top\_n\_accounts](#input\_top\_n\_accounts) | How many worst-offender accounts to list in the Slack message. | `number` | `10` | no |
 
 ## Outputs
 

--- a/terragrunt/audit/config/compliance_report.tf
+++ b/terragrunt/audit/config/compliance_report.tf
@@ -85,7 +85,7 @@ module "compliance_report" {
   lambda_schedule_expression = var.schedule_expression
 
   # Grant write access to the report prefix in the bucket.
-  s3_arn_write_path = "${local.report_bucket_arn}/${var.report_prefix}/*"
+  s3_arn_write_path = "${module.report_bucket.s3_bucket_arn}/${var.report_prefix}/*"
 
   # Extra IAM (Config reads + Organizations).
   lambda_policies = [data.aws_iam_policy_document.report_extra.json]

--- a/terragrunt/audit/config/compliance_report.tf
+++ b/terragrunt/audit/config/compliance_report.tf
@@ -41,36 +41,10 @@ module "report_bucket" {
 }
 
 # ----------------------------------------------------------------------------
-# IAM role for the Lambda
+# IAM policy: AWS Config aggregate reads + Organizations list.
+# (S3 write is granted by the lambda_schedule module via s3_arn_write_path.)
 # ----------------------------------------------------------------------------
-resource "aws_iam_role" "report" {
-  name = "cbrid-compliance-report"
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect    = "Allow"
-      Action    = "sts:AssumeRole"
-      Principal = { Service = "lambda.amazonaws.com" }
-    }]
-  })
-  tags = local.common_tags
-}
-
-data "aws_iam_policy_document" "report" {
-  statement {
-    sid       = "CreateLogGroup"
-    effect    = "Allow"
-    actions   = ["logs:CreateLogGroup"]
-    resources = ["arn:aws:logs:${var.region}:${var.account_id}:*"]
-  }
-
-  statement {
-    sid       = "WriteLogs"
-    effect    = "Allow"
-    actions   = ["logs:CreateLogStream", "logs:PutLogEvents"]
-    resources = ["${aws_cloudwatch_log_group.report.arn}:*"]
-  }
-
+data "aws_iam_policy_document" "report_extra" {
   statement {
     sid    = "ConfigAggregatorRead"
     effect = "Allow"
@@ -82,26 +56,12 @@ data "aws_iam_policy_document" "report" {
   }
 
   statement {
-    sid       = "WriteComplianceReport"
-    effect    = "Allow"
-    actions   = ["s3:PutObject"]
-    resources = ["${aws_s3_bucket.reports.arn}/${var.report_prefix}/*"]
-  }
-
-  statement {
     sid       = "ListAccounts"
     effect    = "Allow"
     actions   = ["organizations:ListAccounts"]
     resources = ["*"]
   }
 }
-
-resource "aws_iam_role_policy" "report" {
-  name   = "cbrid-compliance-report"
-  role   = aws_iam_role.report.id
-  policy = data.aws_iam_policy_document.report.json
-}
-
 
 # ----------------------------------------------------------------------------
 # Lambda (container image) + ECR repo + EventBridge schedule, all from the

--- a/terragrunt/audit/config/compliance_report.tf
+++ b/terragrunt/audit/config/compliance_report.tf
@@ -1,0 +1,142 @@
+# =============================================================================
+# SSC CBRid tag compliance report
+#
+# Lambda that queries the org Config aggregator (created in aggregator.tf) for
+# the require-ssc-cbrid-tag rule, counts compliant/non-compliant resources per
+# account, writes a CSV report to a private S3 bucket, and posts a summary to
+# the SRE bot / Slack. The lambda is triggered Monday morning by an EventBridge
+# rule.
+#
+# =============================================================================
+
+# ----------------------------------------------------------------------------
+# S3 bucket for the CSV reports
+# ----------------------------------------------------------------------------
+module "report_bucket" {
+  source = "github.com/cds-snc/terraform-modules//S3?ref=v11.3.0"
+
+  bucket_name = "cds-ssc-cbrid-compliance-reports"
+
+  billing_tag_value = var.billing_code
+
+  # Private + locked down (these are the module defaults, set explicitly).
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+
+  # Expire old reports.
+  lifecycle_rule = [
+    {
+      id      = "expire-old-reports"
+      enabled = true
+      prefix  = "${var.report_prefix}/"
+      expiration = {
+        days = var.report_retention_days
+      }
+    }
+  ]
+
+  tags = local.common_tags
+}
+
+# ----------------------------------------------------------------------------
+# IAM role for the Lambda
+# ----------------------------------------------------------------------------
+resource "aws_iam_role" "report" {
+  name = "cbrid-compliance-report"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Action    = "sts:AssumeRole"
+      Principal = { Service = "lambda.amazonaws.com" }
+    }]
+  })
+  tags = local.common_tags
+}
+
+data "aws_iam_policy_document" "report" {
+  statement {
+    sid       = "CreateLogGroup"
+    effect    = "Allow"
+    actions   = ["logs:CreateLogGroup"]
+    resources = ["arn:aws:logs:${var.region}:${var.account_id}:*"]
+  }
+
+  statement {
+    sid       = "WriteLogs"
+    effect    = "Allow"
+    actions   = ["logs:CreateLogStream", "logs:PutLogEvents"]
+    resources = ["${aws_cloudwatch_log_group.report.arn}:*"]
+  }
+
+  statement {
+    sid    = "ConfigAggregatorRead"
+    effect = "Allow"
+    actions = [
+      "config:GetAggregateConfigRuleComplianceSummary",
+      "config:GetAggregateComplianceDetailsByConfigRule",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid       = "WriteComplianceReport"
+    effect    = "Allow"
+    actions   = ["s3:PutObject"]
+    resources = ["${aws_s3_bucket.reports.arn}/${var.report_prefix}/*"]
+  }
+
+  statement {
+    sid       = "ListAccounts"
+    effect    = "Allow"
+    actions   = ["organizations:ListAccounts"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "report" {
+  name   = "cbrid-compliance-report"
+  role   = aws_iam_role.report.id
+  policy = data.aws_iam_policy_document.report.json
+}
+
+
+# ----------------------------------------------------------------------------
+# Lambda (container image) + ECR repo + EventBridge schedule, all from the
+# CDS lambda_schedule module.
+# ----------------------------------------------------------------------------
+module "compliance_report" {
+  source = "github.com/cds-snc/terraform-modules//lambda_schedule?ref=v11.3.0"
+
+  lambda_name       = "ssc-cbrid-compliance-report"
+  billing_tag_value = var.billing_code
+
+  # ECR: let the module create the repository; build & push the image to it
+  # image_tag defaults to "latest".
+  create_ecr_repository = true
+  lambda_image_tag      = var.lambda_image_tag
+
+  lambda_timeout = 120
+  lambda_memory  = 256
+
+  # Run weekly: Monday 06:00 UTC = Monday 01:00 EST.
+  lambda_schedule_expression = var.schedule_expression
+
+  # Grant write access to the report prefix in the bucket.
+  s3_arn_write_path = "${local.report_bucket_arn}/${var.report_prefix}/*"
+
+  # Extra IAM (Config reads + Organizations).
+  lambda_policies = [data.aws_iam_policy_document.report_extra.json]
+
+  lambda_environment_variables = {
+    CONFIG_AGGREGATOR_NAME = aws_config_configuration_aggregator.organization.name
+    CONFIG_RULE_NAME       = var.config_rule_name
+    CONFIG_REGION          = var.region
+    SLACK_WEBHOOK_URL      = var.slack_webhook_url
+    S3_BUCKET              = module.report_bucket.s3_bucket_id
+    S3_PREFIX              = var.report_prefix
+    TOP_N_ACCOUNTS         = tostring(var.top_n_accounts)
+  }
+}

--- a/terragrunt/audit/config/inputs.tf
+++ b/terragrunt/audit/config/inputs.tf
@@ -1,0 +1,45 @@
+# ----------------------------------------------------------------------------
+# Variables specific to ssc cbrid tags compliance report 
+# ----------------------------------------------------------------------------
+
+variable "slack_webhook_url" {
+  description = "Incoming webhook URL for the SRE bot / Slack."
+  type        = string
+  sensitive   = true
+}
+
+variable "config_rule_name" {
+  description = "The Config rule to inspect."
+  type        = string
+  default     = "OrgConfigRule-require-ssc-cbrid-tag-wf6xls0p"
+}
+
+variable "report_prefix" {
+  description = "S3 key prefix under which CSV reports are written."
+  type        = string
+  default     = "config-compliance-reports"
+}
+
+variable "top_n_accounts" {
+  description = "How many worst-offender accounts to list in the Slack message."
+  type        = number
+  default     = 10
+}
+
+variable "report_retention_days" {
+  description = "Days to retain report objects before automatic deletion."
+  type        = number
+  default     = 90
+}
+
+variable "schedule_expression" {
+  description = "EventBridge schedule expression in UTC. Empty string disables scheduling."
+  type        = string
+  default     = "cron(0 6 ? * MON *)" # Mondays at 06:00 UTC (1:00am EST) 
+}
+
+variable "lambda_image_tag" {
+  description = "ECR image tag the Lambda runs. Bump when you push a new image."
+  type        = string
+  default     = "latest"
+}

--- a/terragrunt/audit/config/lambda/Dockerfile
+++ b/terragrunt/audit/config/lambda/Dockerfile
@@ -1,0 +1,9 @@
+
+# AWS Lambda Python base image (boto3 is included in the runtime).
+FROM public.ecr.aws/lambda/python:3.13
+ 
+# Copy the function code into the Lambda task root.
+COPY lambda_function.py ${LAMBDA_TASK_ROOT}/
+ 
+# Handler: <module>.<function>
+CMD [ "lambda_function.lambda_handler" ]

--- a/terragrunt/audit/config/lambda/ssc_cbrid_lambda_function.py
+++ b/terragrunt/audit/config/lambda/ssc_cbrid_lambda_function.py
@@ -1,0 +1,422 @@
+"""
+Lambda: Report non-compliant resources for a single AWS Config rule to Slack.
+
+Queries the 'cds-cbr-tags-aggregator' organization aggregator for ONE specific
+rule, counts COMPLIANT and NON_COMPLIANT resources per account, and posts a
+compact summary (totals + per-account compliant/non-compliant counts) to a Slack
+channel via an incoming webhook.
+
+Environment variables:
+    CONFIG_AGGREGATOR_NAME  - aggregator name (default: cds-cbr-tags-aggregator)
+    CONFIG_RULE_NAME        - the rule to inspect
+                              (default: OrgConfigRule-require-ssc-cbrid-tag-wf6xls0p)
+    CONFIG_REGION           - region the resources live in (default: ca-central-1)
+    SLACK_WEBHOOK_URL       - Slack incoming webhook URL
+
+Required IAM permissions (Lambda execution role):
+    config:GetAggregateConfigRuleComplianceSummary
+    config:GetAggregateComplianceDetailsByConfigRule
+    s3:PutObject                  (on the report bucket/prefix; to upload the CSV)
+    organizations:ListAccounts    (optional, to resolve account names)
+"""
+
+import json
+import os
+import csv
+import io
+import datetime
+import urllib.request
+import urllib.error
+from urllib.parse import quote
+import boto3
+from botocore.config import Config as BotoConfig
+
+
+CONFIG_AGGREGATOR_NAME = os.environ.get("CONFIG_AGGREGATOR_NAME", "cds-cbr-tags-aggregator")
+CONFIG_RULE_NAME = os.environ.get(
+    "CONFIG_RULE_NAME", "OrgConfigRule-require-ssc-cbrid-tag-wf6xls0p"
+)
+CONFIG_REGION = os.environ.get("CONFIG_REGION", "ca-central-1")
+SLACK_WEBHOOK_URL = os.environ.get("SLACK_WEBHOOK_URL", "")
+# S3 destination for the full CSV report. If S3_BUCKET is unset, the CSV step
+# is skipped and only the summary is posted.
+S3_BUCKET = os.environ.get("S3_BUCKET", "")
+S3_PREFIX = os.environ.get("S3_PREFIX", "config-compliance-reports")
+
+# Explicit timeouts so a stuck call fails fast instead of eating the whole
+# Lambda timeout budget.
+config_client = boto3.client(
+    "config",
+    config=BotoConfig(
+        connect_timeout=5,
+        read_timeout=15,
+        retries={"max_attempts": 3, "mode": "standard"},
+    ),
+)
+s3_client = boto3.client(
+    "s3",
+    region_name=CONFIG_REGION,
+    config=BotoConfig(
+        signature_version="s3v4",
+        s3={"addressing_style": "virtual"},
+    ),
+)
+
+
+def get_account_names():
+    """Best-effort map of account_id -> account name via Organizations.
+
+    Returns {} if the call isn't permitted; the report then uses account IDs.
+    """
+    names = {}
+    try:
+        org = boto3.client("organizations")
+        paginator = org.get_paginator("list_accounts")
+        for page in paginator.paginate():
+            for acct in page["Accounts"]:
+                names[acct["Id"]] = acct["Name"]
+    except Exception as exc:  # noqa: BLE001 - non-fatal
+        print(f"Could not list account names (continuing with IDs only): {exc}")
+    return names
+
+
+def get_accounts_for_rule():
+    """Return the set of account IDs that have data for the target rule.
+
+    Uses get_aggregate_config_rule_compliance_summary, which does NOT require an
+    AccountId and returns per-account compliance for the aggregator. We then
+    query resource details per account (that call requires an AccountId).
+    """
+    account_ids = set()
+    next_token = None
+    while True:
+        kwargs = {
+            "ConfigurationAggregatorName": CONFIG_AGGREGATOR_NAME,
+            "GroupByKey": "ACCOUNT_ID",
+        }
+        if next_token:
+            kwargs["NextToken"] = next_token
+
+        response = config_client.get_aggregate_config_rule_compliance_summary(**kwargs)
+        for item in response.get("AggregateComplianceCounts", []):
+            account_ids.add(item["GroupName"])
+
+        next_token = response.get("NextToken")
+        if not next_token:
+            break
+    return account_ids
+
+
+def _get_resources(account_id, compliance_type):
+    """Return per-resource records of a compliance type for the rule in one account.
+
+    Each record: {account_id, compliance, resource_type, resource_id, region}.
+    """
+    records = []
+    paginator = config_client.get_paginator(
+        "get_aggregate_compliance_details_by_config_rule"
+    )
+    page_iterator = paginator.paginate(
+        ConfigurationAggregatorName=CONFIG_AGGREGATOR_NAME,
+        ConfigRuleName=CONFIG_RULE_NAME,
+        AccountId=account_id,
+        AwsRegion=CONFIG_REGION,
+        ComplianceType=compliance_type,
+    )
+    for page in page_iterator:
+        for result in page.get("AggregateEvaluationResults", []):
+            qualifier = (
+                result.get("EvaluationResultIdentifier", {})
+                .get("EvaluationResultQualifier", {})
+            )
+            records.append(
+                {
+                    "account_id": result.get("AccountId", account_id),
+                    "compliance": compliance_type,
+                    "resource_type": qualifier.get("ResourceType", "unknown"),
+                    "resource_id": qualifier.get("ResourceId", "unknown"),
+                    "region": result.get("AwsRegion", CONFIG_REGION),
+                }
+            )
+    return records
+
+
+def gather_all_resources():
+    """Collect every evaluated resource (both compliance states) for the rule.
+
+    Returns (all_records, counts) where:
+      all_records = list of per-resource dicts (for the CSV)
+      counts      = {account_id: {"compliant": int, "non_compliant": int}}
+    Single pass: counts are derived from the same data used for the CSV, so we
+    don't make duplicate API calls.
+    """
+    all_records = []
+    counts = {}
+    for account_id in sorted(get_accounts_for_rule()):
+        nc = _get_resources(account_id, "NON_COMPLIANT")
+        c = _get_resources(account_id, "COMPLIANT")
+        if not nc and not c:
+            continue  # rule never evaluated anything in this account
+        all_records.extend(nc)
+        all_records.extend(c)
+        counts[account_id] = {"compliant": len(c), "non_compliant": len(nc)}
+    return all_records, counts
+
+
+def build_and_upload_csv(all_records, account_names):
+    """Write all per-resource records to a CSV and upload to S3.
+
+    Returns the s3:// URI of the uploaded object, or None if S3_BUCKET is unset
+    or the upload fails (the summary is still posted in that case).
+    """
+    if not S3_BUCKET:
+        print("S3_BUCKET not set \u2014 skipping CSV upload.")
+        return {"uri": None, "url": None}
+
+    # Build CSV in memory.
+    buffer = io.StringIO()
+    writer = csv.writer(buffer)
+    writer.writerow(
+        ["account_id", "account_name", "compliance", "resource_type",
+         "resource_id", "region", "rule"]
+    )
+    for r in all_records:
+        writer.writerow(
+            [
+                r["account_id"],
+                account_names.get(r["account_id"], ""),
+                r["compliance"],
+                r["resource_type"],
+                r["resource_id"],
+                r["region"],
+                CONFIG_RULE_NAME,
+            ]
+        )
+
+    body = buffer.getvalue().encode("utf-8")
+
+    # Timestamped key: <prefix>/YYYY/MM/DD/<rule>-<timestamp>.csv
+    now = datetime.datetime.now(datetime.timezone.utc)
+    key = (
+        f"{S3_PREFIX}/{now:%Y/%m/%d}/"
+        f"{CONFIG_RULE_NAME}-{now:%Y%m%dT%H%M%SZ}.csv"
+    )
+
+    try:
+        s3_client.put_object(
+            Bucket=S3_BUCKET,
+            Key=key,
+            Body=body,
+            ContentType="text/csv",
+        )
+    except Exception as exc:  # noqa: BLE001 - non-fatal; still post summary
+        print(f"CSV upload to s3://{S3_BUCKET}/{key} failed: {exc}")
+        return {"uri": None, "url": None}
+
+    uri = f"s3://{S3_BUCKET}/{key}"
+    print(f"Uploaded CSV ({len(all_records)} rows, {len(body)} bytes) to {uri}")
+
+    # Build an S3 console URL (NOT a presigned URL). This requires the clicker
+    # to be authenticated in the AWS account with S3 read access to the object,
+    # so only people with access to the account can download the report.
+    console_url = (
+        f"https://{CONFIG_REGION}.console.aws.amazon.com/s3/object/"
+        f"{S3_BUCKET}?region={CONFIG_REGION}&bucketType=general"
+        f"&prefix={quote(key, safe='')}"
+    )
+
+    return {"uri": uri, "url": console_url}
+
+
+def format_slack_message(counts, account_names, report=None):
+    """Build a COMPACT message: org-wide totals plus the top N worst accounts.
+
+    `counts` is {account_id: {"compliant": int, "non_compliant": int}}.
+    The receiving bot rejects large request bodies, so this deliberately sends
+    only totals and a small fixed-size list of the worst offenders rather than
+    one line per account (which fails for large orgs).
+    """
+    if not counts:
+        text = (
+            f":information_source: *{CONFIG_RULE_NAME}*\n"
+            f"No evaluated resources found in the aggregator for this rule."
+        )
+        return {"blocks": [{"type": "section",
+                            "text": {"type": "mrkdwn", "text": text}}]}
+
+    total_non_compliant = sum(c["non_compliant"] for c in counts.values())
+    total_compliant = sum(c["compliant"] for c in counts.values())
+    total_resources = total_non_compliant + total_compliant
+    accounts_with_nc = sum(1 for c in counts.values() if c["non_compliant"] > 0)
+
+    blocks = [
+        {
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": "AWS SSC CBRid tag Compliance Summary",
+                "emoji": True,
+            },
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": (
+                    f"*Rule:* `{CONFIG_RULE_NAME}`\n"
+                    f"*Total resources evaluated:* {total_resources}\n"
+                    f"\u2705 *Compliant:* {total_compliant}    "
+                    f"\u274c *Non-compliant:* {total_non_compliant}\n"
+                    f"*Accounts evaluated:* {len(counts)}    "
+                    f"*Accounts with non-compliance:* {accounts_with_nc}"
+                ),
+            },
+        },
+        {"type": "divider"},
+    ]
+
+    # Top N worst accounts by non-compliant count. Fixed size keeps the body
+    # small regardless of how many accounts exist in the org.
+    top_n = int(os.environ.get("TOP_N_ACCOUNTS", "10"))
+    ordered = sorted(
+        counts.items(), key=lambda kv: kv[1]["non_compliant"], reverse=True
+    )[:top_n]
+
+    lines = []
+    for account_id, c in ordered:
+        name = account_names.get(account_id, account_id)
+        lines.append(
+            f"\u2022 *{name}*: "
+            f"\u2705 {c['compliant']}  /  "
+            f"\u274c {c['non_compliant']}"
+        )
+
+    blocks.append(
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"*Top {len(lines)} accounts by non-compliance:*\n"
+                        + "\n".join(lines),
+            },
+        }
+    )
+
+    if report and report.get("url"):
+        blocks.append(
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"*<{report['url']}|\U0001F4C4 Open full report (CSV) "
+                            f"in S3 console>*\n"
+                            f"_Requires AWS sign-in to the account._",
+                },
+            }
+        )
+    elif report and report.get("uri"):
+        blocks.append(
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"*Full report (CSV):* `{report['uri']}`",
+                },
+            }
+        )
+
+    blocks.append(
+        {
+            "type": "context",
+            "elements": [
+                {"type": "mrkdwn",
+                 "text": "\u2705 = compliant   \u274c = non-compliant"}
+            ],
+        }
+    )
+
+    return {"blocks": blocks}
+
+
+def post_to_slack(message):
+    """POST the message payload to the Slack incoming webhook."""
+    if not SLACK_WEBHOOK_URL:
+        raise ValueError("SLACK_WEBHOOK_URL environment variable is not set")
+
+    # Diagnostic: reveal the shape of the configured URL without leaking the
+    # secret token. Catches stray quotes/whitespace and wrong host/path.
+    url = SLACK_WEBHOOK_URL
+    stripped = url.strip().strip('"').strip("'")
+    print(
+        f"Webhook check: len={len(url)} stripped_len={len(stripped)} "
+        f"startswith_https={stripped.startswith('https://hooks.slack.com/')} "
+        f"has_leading_trailing_ws={url != url.strip()} "
+        f"prefix={stripped[:34]!r}"
+    )
+    # Use the cleaned value in case the env var picked up quotes/whitespace.
+    effective_url = stripped
+
+    data = json.dumps(message).encode("utf-8")
+    print(f"Slack payload bytes: {len(data)}; blocks: {len(message.get('blocks', []))}")
+    req = urllib.request.Request(
+        effective_url,
+        data=data,
+        headers={
+            "Content-Type": "application/json",
+            # Slack's edge/CDN returns a generic HTML 403 for requests using the
+            # default 'Python-urllib/x.y' agent. Send an explicit User-Agent.
+            "User-Agent": "config-compliance-report/1.0",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            body = resp.read().decode("utf-8")
+            if resp.status != 200 or body != "ok":
+                print(f"Slack returned status={resp.status} body={body}")
+            return resp.status
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8")
+        print(f"Slack rejected request: HTTP {exc.code} \u2014 {detail}")
+        raise
+    except urllib.error.URLError as exc:
+        print(f"Slack webhook URLError: {exc.reason}")
+        raise
+
+
+def lambda_handler(event, context):
+    """Entry point."""
+    print(f"Querying rule '{CONFIG_RULE_NAME}' in aggregator "
+          f"'{CONFIG_AGGREGATOR_NAME}' ({CONFIG_REGION})")
+
+    all_records, counts = gather_all_resources()
+    total_nc = sum(c["non_compliant"] for c in counts.values())
+    total_c = sum(c["compliant"] for c in counts.values())
+    print(f"Accounts: {len(counts)} | compliant: {total_c} | "
+          f"non-compliant: {total_nc} | total rows: {len(all_records)}")
+
+    account_names = get_account_names()
+
+    # Write the full per-resource detail to a CSV in S3 (if configured) and get
+    # a clickable presigned download link.
+    report = build_and_upload_csv(all_records, account_names)
+
+    message = format_slack_message(counts, account_names, report=report)
+
+    print("Posting to Slack")
+    status = post_to_slack(message)
+
+    summary = {
+        "rule": CONFIG_RULE_NAME,
+        "accounts": len(counts),
+        "compliant_resources": total_c,
+        "noncompliant_resources": total_nc,
+        "csv_uri": report.get("uri"),
+        "slack_status": status,
+    }
+    print(json.dumps(summary))
+    return {"statusCode": 200, "body": json.dumps(summary)}
+
+
+if __name__ == "__main__":
+    print(lambda_handler({}, None))

--- a/terragrunt/audit/config/lambda/ssc_cbrid_lambda_function.py
+++ b/terragrunt/audit/config/lambda/ssc_cbrid_lambda_function.py
@@ -1,23 +1,12 @@
 """
 Lambda: Report non-compliant resources for a single AWS Config rule to Slack.
 
-Queries the 'cds-cbr-tags-aggregator' organization aggregator for ONE specific
+Queries the 'cds-cbr-tags-aggregator' organization aggregator for one specific
 rule, counts COMPLIANT and NON_COMPLIANT resources per account, and posts a
 compact summary (totals + per-account compliant/non-compliant counts) to a Slack
-channel via an incoming webhook.
-
-Environment variables:
-    CONFIG_AGGREGATOR_NAME  - aggregator name (default: cds-cbr-tags-aggregator)
-    CONFIG_RULE_NAME        - the rule to inspect
-                              (default: OrgConfigRule-require-ssc-cbrid-tag-wf6xls0p)
-    CONFIG_REGION           - region the resources live in (default: ca-central-1)
-    SLACK_WEBHOOK_URL       - Slack incoming webhook URL
-
-Required IAM permissions (Lambda execution role):
-    config:GetAggregateConfigRuleComplianceSummary
-    config:GetAggregateComplianceDetailsByConfigRule
-    s3:PutObject                  (on the report bucket/prefix; to upload the CSV)
-    organizations:ListAccounts    (optional, to resolve account names)
+channel via an incoming webhook. Additionally, a detailed CSV report with one line 
+per evaluated resource is uploaded to S3, and a link to the report is included in 
+the Slack message.
 """
 
 import json
@@ -83,9 +72,9 @@ def get_account_names():
 def get_accounts_for_rule():
     """Return the set of account IDs that have data for the target rule.
 
-    Uses get_aggregate_config_rule_compliance_summary, which does NOT require an
+    Uses get_aggregate_config_rule_compliance_summary, which does not require an
     AccountId and returns per-account compliance for the aggregator. We then
-    query resource details per account (that call requires an AccountId).
+    query resource details per account.
     """
     account_ids = set()
     next_token = None
@@ -216,7 +205,7 @@ def build_and_upload_csv(all_records, account_names):
     uri = f"s3://{S3_BUCKET}/{key}"
     print(f"Uploaded CSV ({len(all_records)} rows, {len(body)} bytes) to {uri}")
 
-    # Build an S3 console URL (NOT a presigned URL). This requires the clicker
+    # Build an S3 console URL. This requires the clicker/user clicking the link
     # to be authenticated in the AWS account with S3 read access to the object,
     # so only people with access to the account can download the report.
     console_url = (
@@ -234,7 +223,7 @@ def format_slack_message(counts, account_names, report=None):
     `counts` is {account_id: {"compliant": int, "non_compliant": int}}.
     The receiving bot rejects large request bodies, so this deliberately sends
     only totals and a small fixed-size list of the worst offenders rather than
-    one line per account (which fails for large orgs).
+    one line per account (which fails if many accounts exist in the org). 
     """
     if not counts:
         text = (
@@ -343,8 +332,6 @@ def post_to_slack(message):
     if not SLACK_WEBHOOK_URL:
         raise ValueError("SLACK_WEBHOOK_URL environment variable is not set")
 
-    # Diagnostic: reveal the shape of the configured URL without leaking the
-    # secret token. Catches stray quotes/whitespace and wrong host/path.
     url = SLACK_WEBHOOK_URL
     stripped = url.strip().strip('"').strip("'")
     print(
@@ -353,7 +340,6 @@ def post_to_slack(message):
         f"has_leading_trailing_ws={url != url.strip()} "
         f"prefix={stripped[:34]!r}"
     )
-    # Use the cleaned value in case the env var picked up quotes/whitespace.
     effective_url = stripped
 
     data = json.dumps(message).encode("utf-8")
@@ -363,8 +349,6 @@ def post_to_slack(message):
         data=data,
         headers={
             "Content-Type": "application/json",
-            # Slack's edge/CDN returns a generic HTML 403 for requests using the
-            # default 'Python-urllib/x.y' agent. Send an explicit User-Agent.
             "User-Agent": "config-compliance-report/1.0",
         },
         method="POST",
@@ -398,7 +382,7 @@ def lambda_handler(event, context):
     account_names = get_account_names()
 
     # Write the full per-resource detail to a CSV in S3 (if configured) and get
-    # a clickable presigned download link.
+    # a clickable download link.
     report = build_and_upload_csv(all_records, account_names)
 
     message = format_slack_message(counts, account_names, report=report)


### PR DESCRIPTION
# Summary | Résumé

Adds a scheduled Lambda in the audit account that reports on ssc_cbrid tag compliance across the organization.
The function queries the cds-cbr-tags-aggregator Config aggregator for the require-ssc-cbrid-tag rule, tallies compliant and non-compliant resources per account, and posts a summary to Slack via the SRE bot webhook. It also writes a full per-resource CSV report to a private S3 bucket and links to it (S3 console URL, so access requires AWS sign-in to the account). Runs weekly on Monday at 1:00 AM EST.

<img width="621" height="596" alt="Screenshot 2026-05-25 at 5 13 52 PM" src="https://github.com/user-attachments/assets/9cc97ac8-1efb-48c3-8173-35d722367a6c" />
