### PR TITLE
fix: make version number in apply into a comment

### DIFF
--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -131,7 +131,7 @@ jobs:
         uses: cds-snc/terraform-tools-setup@v1.3.0
 
       - name: Configure aws credentials using OIDC
-        uses: aws-actions/configure-aws-credentials@acca2b1b2070338fb9fd1ca27ecee81d687e58e5 v6.1.2
+        uses: aws-actions/configure-aws-credentials@acca2b1b2070338fb9fd1ca27ecee81d687e58e5 #v6.1.2
         with:
           role-to-assume: arn:aws:iam::${{ matrix.account }}:role/${{ matrix.role }}
           role-session-name: ${{matrix.account}}-${{matrix.module}}-apply


### PR DESCRIPTION
This pull request makes a minor change to the workflow configuration by commenting out the version tag for the AWS credentials action in the `.github/workflows/tf-apply.yml` file. This means the workflow will now use the specific commit hash for the action, rather than the version tag.

* Workflow configuration:
  * Updated the `aws-actions/configure-aws-credentials` step to reference only the commit hash, commenting out the explicit version tag (`v6.1.2`) in `.github/workflows/tf-apply.yml`.