### PR TITLE
AWS Config Lambda evaluator

### DIFF
--- a/terragrunt/audit/config/config_rules.tf
+++ b/terragrunt/audit/config/config_rules.tf
@@ -93,8 +93,8 @@ resource "aws_config_organization_custom_rule" "require_ssc_cbrid" {
   lambda_function_arn = aws_lambda_function.ssc_cbrid_evaluator.arn
 
   trigger_types = [
-    "CONFIGURATION_ITEM_CHANGE",
-    "OVERSIZED_CONFIGURATION_ITEM_CHANGE",
+    "ConfigurationItemChangeNotification",
+    "OversizedConfigurationItemChangeNotification",
   ]
 
   # Empty = all supported resource types; new AWS types are covered automatically.

--- a/terragrunt/audit/config/config_rules.tf
+++ b/terragrunt/audit/config/config_rules.tf
@@ -69,6 +69,13 @@ resource "aws_lambda_function" "ssc_cbrid_evaluator" {
   tags = local.common_tags
 }
 
+resource "aws_cloudwatch_log_group" "ssc_cbrid_evaluator" {
+  name              = "/aws/lambda/${aws_lambda_function.ssc_cbrid_evaluator.function_name}"
+  retention_in_days = 14
+
+  tags = local.common_tags
+}
+
 # Allow AWS Config to invoke the Lambda
 resource "aws_lambda_permission" "config_can_invoke_evaluator" {
   statement_id  = "AllowConfigToInvoke"

--- a/terragrunt/audit/config/config_rules.tf
+++ b/terragrunt/audit/config/config_rules.tf
@@ -1,8 +1,8 @@
 # Config rule auditing all resources to determine ssc_cbrid tag compliance.
 #
 # A single custom Lambda-backed rule handles the split logic:
-#   - Platform/shared resources (IAM, VPC, ELB, KMS, S3, EBS, etc.) → 22DH only
-#   - All other resource types                                        → 22DI, 21JC, or 22DJ
+#   - Platform core/shared resources (IAM, VPC, ELB, KMS, S3, EBS, etc.) → 22DH only
+#   - All other resource types → 22DI, 21JC, or 22DJ
 #
 # Using a custom rule means new AWS resource types are covered automatically
 # without any Terraform changes.
@@ -89,7 +89,7 @@ resource "aws_lambda_permission" "config_can_invoke_evaluator" {
 # ----------------------------------------------------------------------------
 resource "aws_config_organization_custom_rule" "require_ssc_cbrid" {
   name                = "require-ssc-cbrid-tag"
-  description         = "Platform resources must use ssc_cbrid=22DH; all other resources must use 22DI, 21JC, or 22DJ"
+  description         = "Platform core resources must use ssc_cbrid=22DH; all other resources must use 22DI, 21JC, or 22DJ"
   lambda_function_arn = aws_lambda_function.ssc_cbrid_evaluator.arn
 
   trigger_types = [

--- a/terragrunt/audit/config/config_rules.tf
+++ b/terragrunt/audit/config/config_rules.tf
@@ -1,20 +1,99 @@
-# Config rule auditing all resources to determine ssc_cbrid tag compliancy.
+# Config rule auditing all resources to determine ssc_cbrid tag compliance.
+#
+# A single custom Lambda-backed rule handles the split logic:
+#   - Platform/shared resources (IAM, VPC, ELB, KMS, S3, EBS, etc.) → 22DH only
+#   - All other resource types                                        → 22DI, 21JC, or 22DJ
+#
+# Using a custom rule means new AWS resource types are covered automatically
+# without any Terraform changes.
 
-# Organization-wide managed rule enforcing approved ssc_cbrid tag values
-resource "aws_config_organization_managed_rule" "require_ssc_cbrid" {
-  name            = "require-ssc-cbrid-tag"
-  description     = "Requires the ssc_cbrid tag with an approved value on all resources"
-  rule_identifier = "REQUIRED_TAGS"
+# ----------------------------------------------------------------------------
+# Lambda zip: no external dependencies, packaged from source at plan time.
+# ----------------------------------------------------------------------------
+data "archive_file" "ssc_cbrid_evaluator" {
+  type        = "zip"
+  source_file = "${path.module}/lambda/ssc_cbrid_config_evaluator.py"
+  output_path = "${path.module}/lambda/ssc_cbrid_config_evaluator.zip"
+}
 
-  # Approved CBR IDs for the ssc_cbrid tag
-  input_parameters = jsonencode({
-    tag1Key   = "ssc_cbrid"
-    tag1Value = "22DH,22DI,21JC,22DJ" # Only allow those values for the cbr ids. Comma-separated allowed values
+# ----------------------------------------------------------------------------
+# IAM role for the evaluator Lambda
+# ----------------------------------------------------------------------------
+resource "aws_iam_role" "ssc_cbrid_evaluator" {
+  name = "ssc-cbrid-config-evaluator-lambda"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "lambda.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
   })
 
-  # Scope to specific resource types; empty means all supported types
+  tags = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "ssc_cbrid_evaluator_basic" {
+  role       = aws_iam_role.ssc_cbrid_evaluator.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+data "aws_iam_policy_document" "ssc_cbrid_evaluator" {
+  statement {
+    sid     = "ConfigPutEvaluations"
+    effect  = "Allow"
+    actions = ["config:PutEvaluations"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "ssc_cbrid_evaluator" {
+  name   = "ssc-cbrid-config-put-evaluations"
+  role   = aws_iam_role.ssc_cbrid_evaluator.id
+  policy = data.aws_iam_policy_document.ssc_cbrid_evaluator.json
+}
+
+# ----------------------------------------------------------------------------
+# Lambda function
+# ----------------------------------------------------------------------------
+resource "aws_lambda_function" "ssc_cbrid_evaluator" {
+  function_name    = "ssc-cbrid-config-evaluator"
+  filename         = data.archive_file.ssc_cbrid_evaluator.output_path
+  source_code_hash = data.archive_file.ssc_cbrid_evaluator.output_base64sha256
+  role             = aws_iam_role.ssc_cbrid_evaluator.arn
+  handler          = "ssc_cbrid_config_evaluator.lambda_handler"
+  runtime          = "python3.12"
+  timeout          = 60
+
+  tags = local.common_tags
+}
+
+# Allow AWS Config to invoke the Lambda
+resource "aws_lambda_permission" "config_can_invoke_evaluator" {
+  statement_id  = "AllowConfigToInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.ssc_cbrid_evaluator.function_name
+  principal     = "config.amazonaws.com"
+}
+
+# ----------------------------------------------------------------------------
+# Custom org-wide Config rule
+# ----------------------------------------------------------------------------
+resource "aws_config_organization_custom_rule" "require_ssc_cbrid" {
+  name                = "require-ssc-cbrid-tag"
+  description         = "Platform resources must use ssc_cbrid=22DH; all other resources must use 22DI, 21JC, or 22DJ"
+  lambda_function_arn = aws_lambda_function.ssc_cbrid_evaluator.arn
+
+  trigger_types = [
+    "CONFIGURATION_ITEM_CHANGE",
+    "OVERSIZED_CONFIGURATION_ITEM_CHANGE",
+  ]
+
+  # Empty = all supported resource types; new AWS types are covered automatically.
   resource_types_scope = []
 
-  # Accounts excluded from this rule (e.g., sandbox or test accounts)
   excluded_accounts = []
+
+  depends_on = [aws_lambda_permission.config_can_invoke_evaluator]
 }

--- a/terragrunt/audit/config/config_rules.tf
+++ b/terragrunt/audit/config/config_rules.tf
@@ -41,9 +41,9 @@ resource "aws_iam_role_policy_attachment" "ssc_cbrid_evaluator_basic" {
 
 data "aws_iam_policy_document" "ssc_cbrid_evaluator" {
   statement {
-    sid     = "ConfigPutEvaluations"
-    effect  = "Allow"
-    actions = ["config:PutEvaluations"]
+    sid       = "ConfigPutEvaluations"
+    effect    = "Allow"
+    actions   = ["config:PutEvaluations"]
     resources = ["*"]
   }
 }

--- a/terragrunt/audit/config/inputs.tf
+++ b/terragrunt/audit/config/inputs.tf
@@ -9,9 +9,9 @@ variable "slack_webhook_url" {
 }
 
 variable "config_rule_name" {
-  description = "The Config rule to inspect."
+  description = "The Config rule to inspect (AWS appends a suffix to the rule name when deployed org-wide)."
   type        = string
-  default     = "OrgConfigRule-require-ssc-cbrid-tag-wf6xls0p"
+  default     = "OrgConfigRule-require-ssc-cbrid-tag"
 }
 
 variable "report_prefix" {

--- a/terragrunt/audit/config/lambda/ssc_cbrid_config_evaluator.py
+++ b/terragrunt/audit/config/lambda/ssc_cbrid_config_evaluator.py
@@ -2,7 +2,7 @@
 Custom AWS Config rule evaluator: require-ssc-cbrid-tag
 
 Enforces the ssc_cbrid tag on every evaluated resource with split logic:
-  - Platform/shared resources  → tag value must be "22DH"
+  - Platform core/sharedresources  → tag value must be "22DH"
   - All other resource types   → tag value must be one of "22DI", "21JC", "22DJ"
 
 Because "all other" is evaluated by exclusion rather than enumeration, new
@@ -15,44 +15,96 @@ import boto3
 
 config_client = boto3.client("config")
 
-# Resource types that belong to the shared platform / landing zone.
-# These must always carry ssc_cbrid=22DH.
-PLATFORM_RESOURCE_TYPES = frozenset([
+# Exact AWS Config resource types that belong to platform core/shared services.
+PLATFORM_CORE_RESOURCE_TYPES = frozenset([
     # IAM
     "AWS::IAM::Group",
-    "AWS::IAM::Policy",
+    "AWS::IAM::ManagedPolicy",
     "AWS::IAM::Role",
     "AWS::IAM::User",
+    "AWS::IAM::InstanceProfile",
+    # Cognito
+    "AWS::Cognito::UserPool",
+    "AWS::Cognito::IdentityPool",
     # VPC & networking
     "AWS::EC2::VPC",
     "AWS::EC2::Subnet",
+    "AWS::EC2::SecurityGroup",
     "AWS::EC2::RouteTable",
     "AWS::EC2::InternetGateway",
-    "AWS::EC2::NetworkAcl",
-    "AWS::EC2::NetworkInterface",
-    "AWS::EC2::SecurityGroup",
+    "AWS::EC2::NatGateway",
+    "AWS::EC2::VPCEndpoint",
     "AWS::EC2::CustomerGateway",
     "AWS::EC2::VPNConnection",
     "AWS::EC2::VPNGateway",
     # Load balancing
     "AWS::ElasticLoadBalancing::LoadBalancer",
     "AWS::ElasticLoadBalancingV2::LoadBalancer",
-    # Security / secrets
+    "AWS::ElasticLoadBalancingV2::TargetGroup",
+    "AWS::ElasticLoadBalancingV2::Listener",
+    "AWS::ElasticLoadBalancingV2::ListenerRule",
+    # WAF / Shield
+    "AWS::WAFv2::WebACL",
+    "AWS::Shield::Protection",
+    # GuardDuty
+    "AWS::GuardDuty::Detector",
+    # KMS / secrets
     "AWS::KMS::Key",
+    "AWS::KMS::Alias",
+    "AWS::SecretsManager::Secret",
+    # CloudWatch
+    "AWS::CloudWatch::Alarm",
+    "AWS::CloudWatch::Dashboard",
+    "AWS::Logs::LogGroup",
+    # CloudFormation
+    "AWS::CloudFormation::Stack",
+    "AWS::CloudFormation::StackSet",
     # Storage
     "AWS::S3::Bucket",
     "AWS::EC2::Volume",
-    # Automation & IaC
-    "AWS::CloudFormation::Stack",
+    "AWS::EC2::Snapshot",
+    # Systems Manager
+    "AWS::SSM::Document",
+    "AWS::SSM::Parameter",
+    # Code pipeline/build
+    "AWS::CodePipeline::Pipeline",
     "AWS::CodeBuild::Project",
     # Messaging
     "AWS::SQS::Queue",
     "AWS::SNS::Topic",
+    "AWS::SNS::Subscription",
+    # Step Functions
+    "AWS::StepFunctions::StateMachine",
+    "AWS::StepFunctions::Activity",
 ])
 
-PLATFORM_ALLOWED = frozenset(["22DH"])
+# Prefix-based families used for wildcard requests like aws_dx_*, aws_backup_*,
+# aws_securityhub_*, aws_guardduty_*, aws_config_*, and aws_ssm_*.
+PLATFORM_CORE_RESOURCE_TYPE_PREFIXES = (
+    "AWS::DirectConnect::",
+    "AWS::EC2::VPN",
+    "AWS::GuardDuty::",
+    "AWS::SecurityHub::",
+    "AWS::Config::",
+    "AWS::Backup::",
+    "AWS::SSM::",
+)
+
+PLATFORM_CORE_ALLOWED = frozenset(["22DH"])
 WORKLOAD_ALLOWED = frozenset(["22DI", "21JC", "22DJ"])
 TAG_KEY = "ssc_cbrid"
+
+# Known AWS Config resource types that do not support resource tagging.
+# These are marked NOT_APPLICABLE instead of NON_COMPLIANT.
+UNTAGGABLE_RESOURCE_TYPES = frozenset([
+    "AWS::ElasticLoadBalancingV2::Listener",
+    "AWS::ElasticLoadBalancingV2::ListenerRule",
+    "AWS::KMS::Alias",
+    "AWS::CloudWatch::Dashboard",
+    "AWS::SNS::Subscription",
+    "AWS::Config::ResourceCompliance",
+    "AWS::Config::ConformancePackCompliance",
+])
 
 # Config item statuses where the resource no longer exists.
 DELETED_STATUSES = frozenset([
@@ -65,7 +117,13 @@ DELETED_STATUSES = frozenset([
 def evaluate_compliance(config_item):
     """Return (compliance_type, annotation) for a single configuration item."""
     resource_type = config_item.get("resourceType", "")
-    allowed = PLATFORM_ALLOWED if resource_type in PLATFORM_RESOURCE_TYPES else WORKLOAD_ALLOWED
+    if is_untaggable_resource_type(resource_type):
+        return (
+            "NOT_APPLICABLE",
+            f"Resource type '{resource_type}' is not taggable.",
+        )
+
+    allowed = PLATFORM_CORE_ALLOWED if is_platform_resource_type(resource_type) else WORKLOAD_ALLOWED
 
     tags = config_item.get("tags") or {}
     tag_value = tags.get(TAG_KEY)
@@ -87,12 +145,54 @@ def evaluate_compliance(config_item):
     return "COMPLIANT", f"Tag '{TAG_KEY}={tag_value}' is present and allowed."
 
 
+def is_platform_resource_type(resource_type):
+    """Return True when a resource type is in the platform_core/shared scope."""
+    if resource_type in PLATFORM_CORE_RESOURCE_TYPES:
+        return True
+    return any(resource_type.startswith(prefix) for prefix in PLATFORM_CORE_RESOURCE_TYPE_PREFIXES)
+
+
+def is_untaggable_resource_type(resource_type):
+    """Return True when a resource type is known to not support tagging."""
+    return resource_type in UNTAGGABLE_RESOURCE_TYPES
+
+
+def get_configuration_item(invoking_event):
+    """Return a configuration item from either regular or oversized Config events."""
+    config_item = invoking_event.get("configurationItem")
+    if config_item:
+        return config_item
+
+    summary = invoking_event.get("configurationItemSummary")
+    if not summary:
+        return None
+
+    capture_time = summary.get("configurationItemCaptureTime")
+    later_time = None
+    if capture_time:
+        try:
+            later_time = datetime.datetime.fromisoformat(
+                capture_time.replace("Z", "+00:00")
+            )
+        except ValueError:
+            later_time = None
+
+    response = config_client.get_resource_config_history(
+        resourceType=summary["resourceType"],
+        resourceId=summary["resourceId"],
+        laterTime=later_time,
+        limit=1,
+    )
+    items = response.get("configurationItems", [])
+    return items[0] if items else None
+
+
 def lambda_handler(event, context):
     """Entry point invoked by AWS Config on every configuration change."""
     invoking_event = json.loads(event["invokingEvent"])
     result_token = event["resultToken"]
 
-    config_item = invoking_event.get("configurationItem")
+    config_item = get_configuration_item(invoking_event)
     if not config_item:
         # Scheduled re-evaluation with no specific item — nothing to do.
         config_client.put_evaluations(Evaluations=[], ResultToken=result_token)

--- a/terragrunt/audit/config/lambda/ssc_cbrid_config_evaluator.py
+++ b/terragrunt/audit/config/lambda/ssc_cbrid_config_evaluator.py
@@ -1,0 +1,130 @@
+"""
+Custom AWS Config rule evaluator: require-ssc-cbrid-tag
+
+Enforces the ssc_cbrid tag on every evaluated resource with split logic:
+  - Platform/shared resources  → tag value must be "22DH"
+  - All other resource types   → tag value must be one of "22DI", "21JC", "22DJ"
+
+Because "all other" is evaluated by exclusion rather than enumeration, new
+AWS resource types are automatically covered without any code change.
+"""
+
+import json
+import datetime
+import boto3
+
+config_client = boto3.client("config")
+
+# Resource types that belong to the shared platform / landing zone.
+# These must always carry ssc_cbrid=22DH.
+PLATFORM_RESOURCE_TYPES = frozenset([
+    # IAM
+    "AWS::IAM::Group",
+    "AWS::IAM::Policy",
+    "AWS::IAM::Role",
+    "AWS::IAM::User",
+    # VPC & networking
+    "AWS::EC2::VPC",
+    "AWS::EC2::Subnet",
+    "AWS::EC2::RouteTable",
+    "AWS::EC2::InternetGateway",
+    "AWS::EC2::NetworkAcl",
+    "AWS::EC2::NetworkInterface",
+    "AWS::EC2::SecurityGroup",
+    "AWS::EC2::CustomerGateway",
+    "AWS::EC2::VPNConnection",
+    "AWS::EC2::VPNGateway",
+    # Load balancing
+    "AWS::ElasticLoadBalancing::LoadBalancer",
+    "AWS::ElasticLoadBalancingV2::LoadBalancer",
+    # Security / secrets
+    "AWS::KMS::Key",
+    # Storage
+    "AWS::S3::Bucket",
+    "AWS::EC2::Volume",
+    # Automation & IaC
+    "AWS::CloudFormation::Stack",
+    "AWS::CodeBuild::Project",
+    # Messaging
+    "AWS::SQS::Queue",
+    "AWS::SNS::Topic",
+])
+
+PLATFORM_ALLOWED = frozenset(["22DH"])
+WORKLOAD_ALLOWED = frozenset(["22DI", "21JC", "22DJ"])
+TAG_KEY = "ssc_cbrid"
+
+# Config item statuses where the resource no longer exists.
+DELETED_STATUSES = frozenset([
+    "ResourceDeleted",
+    "ResourceNotRecorded",
+    "ResourceDeletedNotRecorded",
+])
+
+
+def evaluate_compliance(config_item):
+    """Return (compliance_type, annotation) for a single configuration item."""
+    resource_type = config_item.get("resourceType", "")
+    allowed = PLATFORM_ALLOWED if resource_type in PLATFORM_RESOURCE_TYPES else WORKLOAD_ALLOWED
+
+    tags = config_item.get("tags") or {}
+    tag_value = tags.get(TAG_KEY)
+
+    if tag_value is None:
+        return (
+            "NON_COMPLIANT",
+            f"Required tag '{TAG_KEY}' is missing. "
+            f"Expected one of: {sorted(allowed)}",
+        )
+
+    if tag_value not in allowed:
+        return (
+            "NON_COMPLIANT",
+            f"Tag '{TAG_KEY}' has value '{tag_value}' which is not in the "
+            f"allowed set for this resource type: {sorted(allowed)}",
+        )
+
+    return "COMPLIANT", f"Tag '{TAG_KEY}={tag_value}' is present and allowed."
+
+
+def lambda_handler(event, context):
+    """Entry point invoked by AWS Config on every configuration change."""
+    invoking_event = json.loads(event["invokingEvent"])
+    result_token = event["resultToken"]
+
+    config_item = invoking_event.get("configurationItem")
+    if not config_item:
+        # Scheduled re-evaluation with no specific item — nothing to do.
+        config_client.put_evaluations(Evaluations=[], ResultToken=result_token)
+        return
+
+    if config_item.get("configurationItemStatus") in DELETED_STATUSES:
+        compliance = "NOT_APPLICABLE"
+        annotation = "Resource has been deleted."
+    else:
+        compliance, annotation = evaluate_compliance(config_item)
+
+    # Timestamps from Config are ISO-8601 strings; boto3 requires a datetime.
+    raw_ts = config_item.get("configurationItemCaptureTime", "")
+    try:
+        ordering_ts = datetime.datetime.fromisoformat(raw_ts.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        ordering_ts = datetime.datetime.now(datetime.timezone.utc)
+
+    print(
+        f"resource={config_item['resourceType']}/{config_item['resourceId']} "
+        f"compliance={compliance} annotation={annotation!r}"
+    )
+
+    config_client.put_evaluations(
+        Evaluations=[
+            {
+                "ComplianceResourceType": config_item["resourceType"],
+                "ComplianceResourceId": config_item["resourceId"],
+                "ComplianceType": compliance,
+                "Annotation": annotation,
+                "OrderingTimestamp": ordering_ts,
+            }
+        ],
+        ResultToken=result_token,
+    )

--- a/terragrunt/audit/config/lambda/ssc_cbrid_config_evaluator.py
+++ b/terragrunt/audit/config/lambda/ssc_cbrid_config_evaluator.py
@@ -2,7 +2,7 @@
 Custom AWS Config rule evaluator: require-ssc-cbrid-tag
 
 Enforces the ssc_cbrid tag on every evaluated resource with split logic:
-  - Platform core/sharedresources  → tag value must be "22DH"
+  - Platform core/shared resources  → tag value must be "22DH"
   - All other resource types   → tag value must be one of "22DI", "21JC", "22DJ"
 
 Because "all other" is evaluated by exclusion rather than enumeration, new

--- a/terragrunt/audit/config/lambda/ssc_cbrid_config_evaluator.py
+++ b/terragrunt/audit/config/lambda/ssc_cbrid_config_evaluator.py
@@ -11,9 +11,11 @@ AWS resource types are automatically covered without any code change.
 
 import json
 import datetime
+import logging
 import boto3
 
 config_client = boto3.client("config")
+logger = logging.getLogger(__name__)
 
 # Exact AWS Config resource types that belong to platform core/shared services.
 PLATFORM_CORE_RESOURCE_TYPES = frozenset([
@@ -189,42 +191,41 @@ def get_configuration_item(invoking_event):
 
 def lambda_handler(event, context):
     """Entry point invoked by AWS Config on every configuration change."""
-    invoking_event = json.loads(event["invokingEvent"])
-    result_token = event["resultToken"]
-
-    config_item = get_configuration_item(invoking_event)
-    if not config_item:
-        # Scheduled re-evaluation with no specific item — nothing to do.
-        config_client.put_evaluations(Evaluations=[], ResultToken=result_token)
-        return
-
-    if config_item.get("configurationItemStatus") in DELETED_STATUSES:
-        compliance = "NOT_APPLICABLE"
-        annotation = "Resource has been deleted."
-    else:
-        compliance, annotation = evaluate_compliance(config_item)
-
-    # Timestamps from Config are ISO-8601 strings; boto3 requires a datetime.
-    raw_ts = config_item.get("configurationItemCaptureTime", "")
     try:
-        ordering_ts = datetime.datetime.fromisoformat(raw_ts.replace("Z", "+00:00"))
-    except (ValueError, AttributeError):
-        ordering_ts = datetime.datetime.now(datetime.timezone.utc)
+        invoking_event = json.loads(event["invokingEvent"])
+        result_token = event["resultToken"]
 
-    print(
-        f"resource={config_item['resourceType']}/{config_item['resourceId']} "
-        f"compliance={compliance} annotation={annotation!r}"
-    )
+        config_item = get_configuration_item(invoking_event)
+        if not config_item:
+            # Scheduled re-evaluation with no specific item — nothing to do.
+            config_client.put_evaluations(Evaluations=[], ResultToken=result_token)
+            return
 
-    config_client.put_evaluations(
-        Evaluations=[
-            {
-                "ComplianceResourceType": config_item["resourceType"],
-                "ComplianceResourceId": config_item["resourceId"],
-                "ComplianceType": compliance,
-                "Annotation": annotation,
-                "OrderingTimestamp": ordering_ts,
-            }
-        ],
-        ResultToken=result_token,
-    )
+        if config_item.get("configurationItemStatus") in DELETED_STATUSES:
+            compliance = "NOT_APPLICABLE"
+            annotation = "Resource has been deleted."
+        else:
+            compliance, annotation = evaluate_compliance(config_item)
+
+        # Timestamps from Config are ISO-8601 strings; boto3 requires a datetime.
+        raw_ts = config_item.get("configurationItemCaptureTime", "")
+        try:
+            ordering_ts = datetime.datetime.fromisoformat(raw_ts.replace("Z", "+00:00"))
+        except (ValueError, AttributeError):
+            ordering_ts = datetime.datetime.now(datetime.timezone.utc)
+
+        config_client.put_evaluations(
+            Evaluations=[
+                {
+                    "ComplianceResourceType": config_item["resourceType"],
+                    "ComplianceResourceId": config_item["resourceId"],
+                    "ComplianceType": compliance,
+                    "Annotation": annotation,
+                    "OrderingTimestamp": ordering_ts,
+                }
+            ],
+            ResultToken=result_token,
+        )
+    except Exception:
+        logger.exception("Failed to evaluate Config resource for require-ssc-cbrid-tag")
+        raise

--- a/terragrunt/audit/config/lambda/test_ssc_cbrid_config_evaluator.py
+++ b/terragrunt/audit/config/lambda/test_ssc_cbrid_config_evaluator.py
@@ -35,21 +35,21 @@ def _load_module():
 EVALUATOR = _load_module()
 
 
-class TestPlatformClassification(unittest.TestCase):
-    def test_classifies_exact_platform_type(self):
+class TestPlatformCoreClassification(unittest.TestCase):
+    def test_classifies_exact_platform_core_type(self):
         self.assertTrue(EVALUATOR.is_platform_resource_type("AWS::S3::Bucket"))
 
-    def test_classifies_prefix_platform_type(self):
+    def test_classifies_prefix_platform_core_type(self):
         self.assertTrue(
             EVALUATOR.is_platform_resource_type("AWS::SecurityHub::Hub")
         )
 
-    def test_non_platform_type_is_workload(self):
+    def test_non_platform_core_type_is_workload(self):
         self.assertFalse(EVALUATOR.is_platform_resource_type("AWS::Lambda::Function"))
 
 
 class TestComplianceOutcomes(unittest.TestCase):
-    def test_platform_type_compliant_with_22dh(self):
+    def test_platform_core_type_compliant_with_22dh(self):
         config_item = {
             "resourceType": "AWS::S3::Bucket",
             "tags": {"ssc_cbrid": "22DH"},
@@ -57,7 +57,7 @@ class TestComplianceOutcomes(unittest.TestCase):
         compliance, _ = EVALUATOR.evaluate_compliance(config_item)
         self.assertEqual(compliance, "COMPLIANT")
 
-    def test_platform_type_non_compliant_with_workload_tag(self):
+    def test_platform_core_type_non_compliant_with_workload_tag(self):
         config_item = {
             "resourceType": "AWS::S3::Bucket",
             "tags": {"ssc_cbrid": "22DI"},

--- a/terragrunt/audit/config/lambda/test_ssc_cbrid_config_evaluator.py
+++ b/terragrunt/audit/config/lambda/test_ssc_cbrid_config_evaluator.py
@@ -1,0 +1,156 @@
+"""Unit tests for the custom AWS Config evaluator.
+
+Run with:
+python3 -m unittest terragrunt/audit/config/lambda/test_ssc_cbrid_config_evaluator.py
+"""
+
+import importlib.util
+import pathlib
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+def _load_module():
+    """Load evaluator module while stubbing boto3 config client creation."""
+    module_path = pathlib.Path(__file__).with_name("ssc_cbrid_config_evaluator.py")
+    spec = importlib.util.spec_from_file_location("ssc_cbrid_config_evaluator", module_path)
+    module = importlib.util.module_from_spec(spec)
+
+    fake_boto3 = types.SimpleNamespace(client=lambda *_args, **_kwargs: MagicMock())
+    original_boto3 = sys.modules.get("boto3")
+    sys.modules["boto3"] = fake_boto3
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        if original_boto3 is None:
+            del sys.modules["boto3"]
+        else:
+            sys.modules["boto3"] = original_boto3
+
+    return module
+
+
+EVALUATOR = _load_module()
+
+
+class TestPlatformClassification(unittest.TestCase):
+    def test_classifies_exact_platform_type(self):
+        self.assertTrue(EVALUATOR.is_platform_resource_type("AWS::S3::Bucket"))
+
+    def test_classifies_prefix_platform_type(self):
+        self.assertTrue(
+            EVALUATOR.is_platform_resource_type("AWS::SecurityHub::Hub")
+        )
+
+    def test_non_platform_type_is_workload(self):
+        self.assertFalse(EVALUATOR.is_platform_resource_type("AWS::Lambda::Function"))
+
+
+class TestComplianceOutcomes(unittest.TestCase):
+    def test_platform_type_compliant_with_22dh(self):
+        config_item = {
+            "resourceType": "AWS::S3::Bucket",
+            "tags": {"ssc_cbrid": "22DH"},
+        }
+        compliance, _ = EVALUATOR.evaluate_compliance(config_item)
+        self.assertEqual(compliance, "COMPLIANT")
+
+    def test_platform_type_non_compliant_with_workload_tag(self):
+        config_item = {
+            "resourceType": "AWS::S3::Bucket",
+            "tags": {"ssc_cbrid": "22DI"},
+        }
+        compliance, annotation = EVALUATOR.evaluate_compliance(config_item)
+        self.assertEqual(compliance, "NON_COMPLIANT")
+        self.assertIn("22DH", annotation)
+
+    def test_workload_type_compliant_with_allowed_value(self):
+        config_item = {
+            "resourceType": "AWS::Lambda::Function",
+            "tags": {"ssc_cbrid": "21JC"},
+        }
+        compliance, _ = EVALUATOR.evaluate_compliance(config_item)
+        self.assertEqual(compliance, "COMPLIANT")
+
+    def test_workload_type_non_compliant_with_22dh(self):
+        config_item = {
+            "resourceType": "AWS::Lambda::Function",
+            "tags": {"ssc_cbrid": "22DH"},
+        }
+        compliance, annotation = EVALUATOR.evaluate_compliance(config_item)
+        self.assertEqual(compliance, "NON_COMPLIANT")
+        self.assertIn("22DI", annotation)
+
+    def test_missing_tag_is_non_compliant(self):
+        config_item = {
+            "resourceType": "AWS::EC2::Instance",
+            "tags": {},
+        }
+        compliance, annotation = EVALUATOR.evaluate_compliance(config_item)
+        self.assertEqual(compliance, "NON_COMPLIANT")
+        self.assertIn("missing", annotation)
+
+    def test_untaggable_type_is_not_applicable(self):
+        config_item = {
+            "resourceType": "AWS::Config::ResourceCompliance",
+            "tags": {},
+        }
+        compliance, annotation = EVALUATOR.evaluate_compliance(config_item)
+        self.assertEqual(compliance, "NOT_APPLICABLE")
+        self.assertIn("not taggable", annotation)
+
+    def test_additional_known_untaggable_types_are_not_applicable(self):
+        resource_types = [
+            "AWS::ElasticLoadBalancingV2::Listener",
+            "AWS::ElasticLoadBalancingV2::ListenerRule",
+            "AWS::KMS::Alias",
+            "AWS::CloudWatch::Dashboard",
+            "AWS::SNS::Subscription",
+        ]
+        for resource_type in resource_types:
+            with self.subTest(resource_type=resource_type):
+                config_item = {
+                    "resourceType": resource_type,
+                    "tags": {},
+                }
+                compliance, annotation = EVALUATOR.evaluate_compliance(config_item)
+                self.assertEqual(compliance, "NOT_APPLICABLE")
+                self.assertIn("not taggable", annotation)
+
+
+class TestLambdaHandler(unittest.TestCase):
+    def test_oversized_notification_fetches_configuration_item(self):
+        EVALUATOR.config_client.reset_mock()
+        EVALUATOR.config_client.get_resource_config_history.return_value = {
+            "configurationItems": [
+                {
+                    "resourceType": "AWS::S3::Bucket",
+                    "resourceId": "example-bucket",
+                    "tags": {"ssc_cbrid": "22DH"},
+                    "configurationItemStatus": "OK",
+                    "configurationItemCaptureTime": "2026-06-23T12:00:00.000Z",
+                }
+            ]
+        }
+
+        event = {
+            "invokingEvent": '{"configurationItemSummary": {"resourceType": "AWS::S3::Bucket", "resourceId": "example-bucket", "configurationItemCaptureTime": "2026-06-23T12:00:00.000Z"}}',
+            "resultToken": "token",
+        }
+
+        with patch("builtins.print"):
+            EVALUATOR.lambda_handler(event, None)
+
+        EVALUATOR.config_client.get_resource_config_history.assert_called_once()
+        EVALUATOR.config_client.put_evaluations.assert_called_once()
+        evaluation = EVALUATOR.config_client.put_evaluations.call_args.kwargs[
+            "Evaluations"
+        ][0]
+        self.assertEqual(evaluation["ComplianceType"], "COMPLIANT")
+        self.assertEqual(evaluation["ComplianceResourceType"], "AWS::S3::Bucket")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Summary | Résumé

This change introduces a custom AWS Config Lambda evaluator for ssc_cbrid tag compliance. The rule now enforces 22DH for platform core resources and 22DI, 21JC, or 22DJ for all other resources, while known untaggable resource types are marked NOT_APPLICABLE. It also adds support for oversized AWS Config events, keeps CloudWatch log retention at 14 days, and includes unit tests covering classification, compliance outcomes, and untaggable resources.
