### PR TITLE
Separate Lambda deploy from Terraform apply

### DIFF
--- a/.github/workflows/lambda-deploy-config.yml
+++ b/.github/workflows/lambda-deploy-config.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - "terragrunt/audit/config/lambda/**"
+      - "terragrunt/audit/config/**"
       - ".github/workflows/lambda-deploy-config.yml"
 
 env:

--- a/.github/workflows/lambda-deploy-config.yml
+++ b/.github/workflows/lambda-deploy-config.yml
@@ -1,0 +1,58 @@
+name: "Deploy compliance report Lambda"
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "terragrunt/audit/config/lambda/**"
+      - ".github/workflows/lambda-deploy-config.yml"
+
+env:
+  AWS_REGION: "ca-central-1"
+  AWS_ACCOUNT_ID: 886481071419
+  ECR_REPOSITORY: ssc-cbrid-compliance-report
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy-lambda:
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@acca2b1b2070338fb9fd1ca27ecee81d687e58e5 #v6.1.2
+        with:
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/cds-aws-lz-apply
+          role-session-name: audit-config-lambda-deploy
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+
+      - name: Build and push Lambda image
+        env:
+          ECR_REGISTRY: ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com
+          IMAGE_TAG: ${{ github.sha }}
+        working-directory: terragrunt/audit/config/lambda
+        run: |
+          docker build --provenance=false --platform linux/amd64 \
+            -t "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" \
+            -t "$ECR_REGISTRY/$ECR_REPOSITORY:latest" .
+          docker push "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+          docker push "$ECR_REGISTRY/$ECR_REPOSITORY:latest"
+
+      - name: Update Lambda function code
+        env:
+          ECR_REGISTRY: ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          aws lambda update-function-code \
+            --function-name ssc-cbrid-compliance-report \
+            --image-uri "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"

--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -144,24 +144,6 @@ jobs:
           role-session-name: ${{matrix.account}}-${{matrix.module}}-apply
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Login to Amazon ECR (config only)
-        if: matrix.module == 'config'
-        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
-
-      - name: Build and push Lambda image (config only)
-        if: matrix.module == 'config'
-        working-directory: terragrunt/${{ matrix.account_folder }}/${{ matrix.module }}/lambda
-        env:
-          ECR_REGISTRY: ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com
-          ECR_REPOSITORY: ssc-cbrid-compliance-report
-          IMAGE_TAG: ${{ github.sha }}
-        run: |
-          docker build --provenance=false --platform linux/amd64 \
-            -t "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" \
-            -t "$ECR_REGISTRY/$ECR_REPOSITORY:latest" .
-          docker push "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
-          docker push "$ECR_REGISTRY/$ECR_REPOSITORY:latest"
-
       - name: Terraform apply ${{matrix.account_folder}}/${{ matrix.module }}
         working-directory: terragrunt/${{ matrix.account_folder }}/${{ matrix.module }}
         env:
@@ -177,6 +159,5 @@ jobs:
           TF_VAR_cost_report_po_numbers: ${{ matrix.cost_report_po_numbers && secrets[matrix.cost_report_po_numbers] }}
           TF_VAR_admin_sso_role_arn: ${{ secrets[matrix.admin_sso_role_arn] }}
           TF_VAR_slack_webhook_url: ${{ matrix.slack_webhook_url && secrets[matrix.slack_webhook_url] }}
-          TF_VAR_lambda_image_tag: ${{ github.sha }}
         run: |
           terragrunt --non-interactive apply -auto-approve


### PR DESCRIPTION

# Summary | Résumé

Moves the compliance report Lambda build/push/deploy out of tf-apply.yml nto a dedicated lambda-deploy-config.yml workflow

