### PR TITLE
PR to Synchronize config rule name

### DIFF
--- a/terragrunt/audit/config/README.md
+++ b/terragrunt/audit/config/README.md
@@ -35,7 +35,7 @@
 |------|-------------|------|---------|:--------:|
 | <a name="input_account_id"></a> [account\_id](#input\_account\_id) | (Required) The account ID to perform actions on. | `string` | n/a | yes |
 | <a name="input_billing_code"></a> [billing\_code](#input\_billing\_code) | The billing code to tag our resources with | `string` | n/a | yes |
-| <a name="input_config_rule_name"></a> [config\_rule\_name](#input\_config\_rule\_name) | The Config rule to inspect. | `string` | `"OrgConfigRule-require-ssc-cbrid-tag-wf6xls0p"` | no |
+| <a name="input_config_rule_name"></a> [config\_rule\_name](#input\_config\_rule\_name) | The Config rule to inspect. | `string` | `"OrgConfigRule-require-ssc-cbrid-tag-zwgttrr2"` | no |
 | <a name="input_env"></a> [env](#input\_env) | The current running environment | `string` | n/a | yes |
 | <a name="input_lambda_image_tag"></a> [lambda\_image\_tag](#input\_lambda\_image\_tag) | ECR image tag the Lambda runs. Bump when you push a new image. | `string` | `"latest"` | no |
 | <a name="input_org_account"></a> [org\_account](#input\_org\_account) | The account ID of the main organization account | `any` | n/a | yes |

--- a/terragrunt/audit/config/inputs.tf
+++ b/terragrunt/audit/config/inputs.tf
@@ -11,7 +11,7 @@ variable "slack_webhook_url" {
 variable "config_rule_name" {
   description = "The Config rule to inspect (AWS appends a suffix to the rule name when deployed org-wide)."
   type        = string
-  default     = "OrgConfigRule-require-ssc-cbrid-tag"
+  default     = "OrgConfigRule-require-ssc-cbrid-tag-zwgttrr2"
 }
 
 variable "report_prefix" {

--- a/terragrunt/audit/config/lambda/ssc_cbrid_lambda_function.py
+++ b/terragrunt/audit/config/lambda/ssc_cbrid_lambda_function.py
@@ -23,7 +23,7 @@ from botocore.config import Config as BotoConfig
 
 CONFIG_AGGREGATOR_NAME = os.environ.get("CONFIG_AGGREGATOR_NAME", "cds-cbr-tags-aggregator")
 CONFIG_RULE_NAME = os.environ.get(
-    "CONFIG_RULE_NAME", "OrgConfigRule-require-ssc-cbrid-tag-wf6xls0p"
+    "CONFIG_RULE_NAME", "OrgConfigRule-require-ssc-cbrid-tag-zwgttrr2"
 )
 CONFIG_REGION = os.environ.get("CONFIG_REGION", "ca-central-1")
 SLACK_WEBHOOK_URL = os.environ.get("SLACK_WEBHOOK_URL", "")


### PR DESCRIPTION
# Summary | Résumé

The config name was not synchronized between the rule creation and the compliance report. This PR fixes that. 