### PR TITLE
Remove s3_sources from guardduty_forwarder

### DIFF
--- a/terragrunt/org_account/main/sentinel_aws_s3_connector.tf
+++ b/terragrunt/org_account/main/sentinel_aws_s3_connector.tf
@@ -169,11 +169,23 @@ resource "aws_iam_role" "azure_sentinel" {
   name               = "AzureSentinelRole"
   description        = "Azure Sentinel Integration"
   assume_role_policy = data.aws_iam_policy_document.azure_sentinel_assume_role.json
-  managed_policy_arns = [
+}
+
+# managed_policy_arns on the role above would be authoritative for the role's entire
+# set of managed policy attachments, so it would detach anything attached by an
+# aws_iam_role_policy_attachment resource (see azure_sentinel_guardduty_kms below) on
+# every apply. All attachments are therefore expressed as attachment resources.
+resource "aws_iam_role_policy_attachment" "azure_sentinel" {
+  provider = aws.log_archive
+
+  for_each = toset([
     "arn:aws:iam::aws:policy/AmazonSQSReadOnlyAccess",
     "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
     "arn:aws:iam::aws:policy/service-role/AWSLambdaSQSQueueExecutionRole"
-  ]
+  ])
+
+  role       = aws_iam_role.azure_sentinel.name
+  policy_arn = each.value
 }
 
 # GuardDuty findings in module.publishing_bucket are encrypted with a customer-managed

--- a/terragrunt/org_account/main/sentinel_forwarders.tf
+++ b/terragrunt/org_account/main/sentinel_forwarders.tf
@@ -12,15 +12,6 @@ module "guardduty_forwarder" {
 
   customer_id = var.lw_customer_id
   shared_key  = var.lw_shared_key
-
-  s3_sources = [
-    {
-      bucket_arn    = module.publishing_bucket.s3_bucket_arn
-      bucket_id     = module.publishing_bucket.s3_bucket_id
-      filter_prefix = "AWSLogs/"
-      kms_key_arn   = aws_kms_key.cds_sentinel_guard_duty_key.arn
-    }
-  ]
 }
 
 


### PR DESCRIPTION
This PR fixes the problem with the s3 bucket notification settings and the IAM inconsistency introduced by #448 . 

Detailed explanation generated by AI below:

## Why

GuardDuty findings are now ingested via the native Sentinel **AWS S3 connector** (`aws_s3_bucket_notification.azure_guardduty_bucket_notification` → `azure-sentinel-guardduty-queue`), added in #448. That PR did not touch `sentinel_forwarders.tf`, which still declared `s3_sources` on `module "guardduty_forwarder"`.

The result was **two `aws_s3_bucket_notification` resources targeting the same bucket** (`module.publishing_bucket`) at the same `AWSLogs/` prefix:

| Terraform address | Destination |
| --- | --- |
| `module.guardduty_forwarder.aws_s3_bucket_notification.sentinel_forwarder_trigger_notification[0]` | `sentinel-guard-duty-forwarder` Lambda |
| `aws_s3_bucket_notification.azure_guardduty_bucket_notification` | `azure-sentinel-guardduty-queue` |

`aws_s3_bucket_notification` is authoritative for a bucket's *entire* notification configuration — it is not additive. So each apply, whichever resource is currently live shows no drift and plans nothing, while the other is drifted and re-PUTs its own config, replacing the live one. The two alternate on every apply, silencing either `AWSGuardDuty` or `AWSGuardDuty_CL` each time. Objects written while a notification is absent are never enqueued and cannot be re-notified later, and the bucket expires objects at 14 days — so each flip loses findings permanently.

## Second commit: the same bug in IAM

The first plan on this branch also showed `aws_iam_role.azure_sentinel` being **updated in place to strip `arn:aws:iam::274536870005:policy/azure-sentinel-guardduty-kms-decrypt`**.

Same failure mode: the role set `managed_policy_arns`, which is authoritative for the role's entire set of managed policy attachments, while `aws_iam_role_policy_attachment.azure_sentinel_guardduty_kms` attaches a fourth policy outside that list. The attachment matches live so plans nothing; the role sees an extra ARN and removes it.

Losing `kms:Decrypt` breaks the S3 connector — GuardDuty objects are encrypted with a customer-managed key, so the poller can fetch them but not read them, and `AWSGuardDuty` goes quiet with no Terraform error. This was pre-existing on `main` and would have fired on the next apply of this module by anyone.

Fix: drop `managed_policy_arns` and express all four attachments as `aws_iam_role_policy_attachment` resources, so nothing claims exclusive ownership. `AttachRolePolicy` is idempotent, so the three new attachments reconcile against the live role with no effective permission change. The existing `azure_sentinel_guardduty_kms` resource is deliberately left at its current address to avoid state churn on the attachment that matters.

## Sequencing — state removal is done

1. ✅ Verified live config: one `QueueConfigurations` for `azure-sentinel-guardduty-queue`, no `LambdaFunctionConfigurations`.
2. ✅ `terragrunt state rm 'module.guardduty_forwarder.aws_s3_bucket_notification.sentinel_forwarder_trigger_notification[0]'` — run against `org_account/main` on 2026-07-31. Required because merging applies this module (`tf-apply.yml` runs on push to `main` with no path filter), and destroying an `aws_s3_bucket_notification` PUTs an *empty* notification configuration for the whole bucket, which would have deleted the live queue entry. The pre-removal plan confirmed the danger concretely — that resource had refreshed to hold the **queue** configuration, not the Lambda one.
3. ✅ Post-removal plan is clean: `3 to add, 0 to change, 3 to destroy`, with **no `aws_s3_bucket_notification` in the plan** and **no change to `aws_iam_role.azure_sentinel`**. Remaining destroys are `aws_lambda_permission.sentinel_forwarder_s3_triggers[0]` and two dead `count = 0` IAM resources.

## After merge

Verify immediately:

```bash
aws s3api get-bucket-notification-configuration --bucket terraform-20220502135712124000000002
```

Expect the single `azure-sentinel-guardduty-queue` entry, unchanged. Then confirm `AWSGuardDuty` is still receiving in Sentinel.

## Scope

`module "securityhub_forwarder"` is untouched — EventBridge-triggered, still on the legacy Data Collector API, unaffected. The forwarder Lambda is left as dead code and removed in a follow-up, once `AWSGuardDuty` has been validated against the tail of `AWSGuardDuty_CL` (column names differ between the two tables, so queries and analytics rules must be repointed first).